### PR TITLE
Schakel over op multireporter

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,6 +1,9 @@
 module.exports = {
     "full-trace": true,
-    "reporter": 'spec',
+    "reporter": 'mocha-multi-reporters',
+    "reporter-option": [
+        "configFile=reporter-config.json"
+    ],
     "spec": ["node_modules/vl-ui-*/test/e2e/*.test.js"],
     "timeout": '20000'
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,25 +6,25 @@
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/code-frame/-/code-frame-7.10.4.tgz",
       "integrity": "sha1-Fo2ho26Q2miujUnA8bSMfGJJITo=",
       "requires": {
         "@babel/highlight": "^7.10.4"
       }
     },
     "@babel/core": {
-      "version": "7.11.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/core/-/core-7.11.6.tgz",
-      "integrity": "sha1-OpRV3HOH/xusRXcGULwTugShVlE=",
+      "version": "7.12.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/core/-/core-7.12.3.tgz",
+      "integrity": "sha1-G0NohOHjv/b7EyjcArIIdZ3pKtg=",
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.11.6",
-        "@babel/helper-module-transforms": "^7.11.0",
-        "@babel/helpers": "^7.10.4",
-        "@babel/parser": "^7.11.5",
+        "@babel/generator": "^7.12.1",
+        "@babel/helper-module-transforms": "^7.12.1",
+        "@babel/helpers": "^7.12.1",
+        "@babel/parser": "^7.12.3",
         "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.11.5",
-        "@babel/types": "^7.11.5",
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
@@ -35,51 +35,38 @@
         "source-map": "^0.5.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
-        },
         "semver": {
           "version": "5.7.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-5.7.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/semver/-/semver-5.7.1.tgz",
           "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
     "@babel/generator": {
-      "version": "7.11.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/generator/-/generator-7.11.6.tgz",
-      "integrity": "sha1-uGiQD4GxY7TUZOokVFxhy6xNxiA=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/generator/-/generator-7.12.1.tgz",
+      "integrity": "sha1-DXC+Mr2qA9fFHIWX3aduDfHxVGg=",
       "requires": {
-        "@babel/types": "^7.11.5",
+        "@babel/types": "^7.12.1",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
     "@babel/helper-annotate-as-pure": {
       "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
       "integrity": "sha1-W/DUlaP3V6w72ki1vzs7ownHK6M=",
       "requires": {
         "@babel/types": "^7.10.4"
@@ -87,7 +74,7 @@
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
       "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz",
       "integrity": "sha1-uwt18xv5jL+f8UPBrleLhydK4aM=",
       "requires": {
         "@babel/helper-explode-assignable-expression": "^7.10.4",
@@ -95,18 +82,18 @@
       }
     },
     "@babel/helper-create-regexp-features-plugin": {
-      "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.10.4.tgz",
-      "integrity": "sha1-/dYNiFJGWaC2lZwFeZJeQlcU87g=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.1.tgz",
+      "integrity": "sha1-GLEwLUZ3+dxHQP6MntlmgOKdN+g=",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.10.4",
         "@babel/helper-regex": "^7.10.4",
-        "regexpu-core": "^4.7.0"
+        "regexpu-core": "^4.7.1"
       }
     },
     "@babel/helper-define-map": {
       "version": "7.10.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-define-map/-/helper-define-map-7.10.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-define-map/-/helper-define-map-7.10.5.tgz",
       "integrity": "sha1-tTwQ23imQIABUmkrEzkxR6y5uzA=",
       "requires": {
         "@babel/helper-function-name": "^7.10.4",
@@ -115,16 +102,16 @@
       }
     },
     "@babel/helper-explode-assignable-expression": {
-      "version": "7.11.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.11.4.tgz",
-      "integrity": "sha1-LY40cCUswXq6kX7eeAPUp6J2pBs=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.12.1.tgz",
+      "integrity": "sha1-gAakZmlcSthqKl8vsVtfLDGtVjM=",
       "requires": {
-        "@babel/types": "^7.10.4"
+        "@babel/types": "^7.12.1"
       }
     },
     "@babel/helper-function-name": {
       "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
       "integrity": "sha1-0tOyDFmtjEcRL6fSqUvAnV74Lxo=",
       "requires": {
         "@babel/helper-get-function-arity": "^7.10.4",
@@ -134,45 +121,47 @@
     },
     "@babel/helper-get-function-arity": {
       "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
       "integrity": "sha1-mMHL6g4jMvM/mkZhuM4VBbLBm6I=",
       "requires": {
         "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.11.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
-      "integrity": "sha1-rmnIPYTugvS0L5bioJQQk1qPJt8=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
+      "integrity": "sha1-+6Dy/P8/ugDm7LZku15uJuLWFlw=",
       "requires": {
-        "@babel/types": "^7.11.0"
+        "@babel/types": "^7.12.1"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-      "integrity": "sha1-TFxUvgS9MWcKc4J5fXW5+i5bViA=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-module-imports/-/helper-module-imports-7.12.1.tgz",
+      "integrity": "sha1-FkTAFZGhWi8ITdbQktlDDrHRIWw=",
       "requires": {
-        "@babel/types": "^7.10.4"
+        "@babel/types": "^7.12.1"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.11.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
-      "integrity": "sha1-sW8lAinkchGr3YSzS2RzfCqy01k=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+      "integrity": "sha1-eVT+xx9bMsSOSzA7Q3w0RT/XJHw=",
       "requires": {
-        "@babel/helper-module-imports": "^7.10.4",
-        "@babel/helper-replace-supers": "^7.10.4",
-        "@babel/helper-simple-access": "^7.10.4",
+        "@babel/helper-module-imports": "^7.12.1",
+        "@babel/helper-replace-supers": "^7.12.1",
+        "@babel/helper-simple-access": "^7.12.1",
         "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/helper-validator-identifier": "^7.10.4",
         "@babel/template": "^7.10.4",
-        "@babel/types": "^7.11.0",
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1",
         "lodash": "^4.17.19"
       }
     },
     "@babel/helper-optimise-call-expression": {
       "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
       "integrity": "sha1-UNyWQT1ZT5lad5BZBbBYk813lnM=",
       "requires": {
         "@babel/types": "^7.10.4"
@@ -180,59 +169,57 @@
     },
     "@babel/helper-plugin-utils": {
       "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
       "integrity": "sha1-L3WoMSadT2d95JmG3/WZJ1M883U="
     },
     "@babel/helper-regex": {
       "version": "7.10.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-regex/-/helper-regex-7.10.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-regex/-/helper-regex-7.10.5.tgz",
       "integrity": "sha1-Mt+7eYmQc8QVVXBToZvQVarlCuA=",
       "requires": {
         "lodash": "^4.17.19"
       }
     },
     "@babel/helper-remap-async-to-generator": {
-      "version": "7.11.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.11.4.tgz",
-      "integrity": "sha1-RHTqn3Q48YV14wsMrHhARbQCoS0=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.12.1.tgz",
+      "integrity": "sha1-jE27+RYxT2BH3AXmoiFwdCODR/0=",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.10.4",
         "@babel/helper-wrap-function": "^7.10.4",
-        "@babel/template": "^7.10.4",
-        "@babel/types": "^7.10.4"
+        "@babel/types": "^7.12.1"
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-      "integrity": "sha1-1YXNk4jqBuYDHkzUS2cTy+rZ5s8=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-replace-supers/-/helper-replace-supers-7.12.1.tgz",
+      "integrity": "sha1-8VycyJdDkoGJHhHVzhJWKsDPP6k=",
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.10.4",
+        "@babel/helper-member-expression-to-functions": "^7.12.1",
         "@babel/helper-optimise-call-expression": "^7.10.4",
-        "@babel/traverse": "^7.10.4",
-        "@babel/types": "^7.10.4"
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
-      "integrity": "sha1-D1zNopRSd6KnotOoIeFTle3PNGE=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+      "integrity": "sha1-MkJ+WqYVR9OOsebq9f0UJv2tkTY=",
       "requires": {
-        "@babel/template": "^7.10.4",
-        "@babel/types": "^7.10.4"
+        "@babel/types": "^7.12.1"
       }
     },
     "@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.11.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.11.0.tgz",
-      "integrity": "sha1-7sFi8RLC9Y068K8SXju1dmUUZyk=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.12.1.tgz",
+      "integrity": "sha1-Ri3GOn5DWt6EaDhcY9K4TM5LPL8=",
       "requires": {
-        "@babel/types": "^7.11.0"
+        "@babel/types": "^7.12.1"
       }
     },
     "@babel/helper-split-export-declaration": {
       "version": "7.11.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
       "integrity": "sha1-+KSRJErPamdhWKxCBykRuoOtCZ8=",
       "requires": {
         "@babel/types": "^7.11.0"
@@ -240,13 +227,13 @@
     },
     "@babel/helper-validator-identifier": {
       "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
       "integrity": "sha1-p4x6clHgH2FlEtMbEK3PUq2l4NI="
     },
     "@babel/helper-wrap-function": {
-      "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-wrap-function/-/helper-wrap-function-7.10.4.tgz",
-      "integrity": "sha1-im9wHqsP8592W1oc/vQJmQ5iS4c=",
+      "version": "7.12.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-wrap-function/-/helper-wrap-function-7.12.3.tgz",
+      "integrity": "sha1-MzIzn8TR+78cJ9eVjCfTRwjpkNk=",
       "requires": {
         "@babel/helper-function-name": "^7.10.4",
         "@babel/template": "^7.10.4",
@@ -255,18 +242,18 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helpers/-/helpers-7.10.4.tgz",
-      "integrity": "sha1-Kr6w1yGv98Cpc3a54fb2XXpHUEQ=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helpers/-/helpers-7.12.1.tgz",
+      "integrity": "sha1-ioJhwdQ47BjLiQQ0307HaHNMHnk=",
       "requires": {
         "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.10.4",
-        "@babel/types": "^7.10.4"
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1"
       }
     },
     "@babel/highlight": {
       "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/highlight/-/highlight-7.10.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/highlight/-/highlight-7.10.4.tgz",
       "integrity": "sha1-fRvf1ldTU4+r5sOFls23bZrGAUM=",
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.4",
@@ -276,7 +263,7 @@
       "dependencies": {
         "chalk": {
           "version": "2.4.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -287,41 +274,41 @@
       }
     },
     "@babel/parser": {
-      "version": "7.11.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/parser/-/parser-7.11.5.tgz",
-      "integrity": "sha1-x/9jA99xCA7HpPW4wAPFjxz1EDc="
+      "version": "7.12.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/parser/-/parser-7.12.3.tgz",
+      "integrity": "sha1-owVBXr56bHAjtAtRIqBmLZKDNM0="
     },
     "@babel/plugin-external-helpers": {
-      "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-external-helpers/-/plugin-external-helpers-7.10.4.tgz",
-      "integrity": "sha1-QNOOjkih+jdmq0NJYlMmbKJng84=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-external-helpers/-/plugin-external-helpers-7.12.1.tgz",
+      "integrity": "sha1-30dHdYYLO4vf6u3UVZbNLH82or4=",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.10.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.5.tgz",
-      "integrity": "sha1-NJHKvy98F5q4IGBs7Cf+0V4OhVg=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.1.tgz",
+      "integrity": "sha1-3GwRcOJ9isqZ/2X0klvQaxyQVQ4=",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/helper-remap-async-to-generator": "^7.10.4",
+        "@babel/helper-remap-async-to-generator": "^7.12.1",
         "@babel/plugin-syntax-async-generators": "^7.8.0"
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.11.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.11.0.tgz",
-      "integrity": "sha1-vYH5Wh90Z2DqQ7bC09YrEXkK0K8=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.12.1.tgz",
+      "integrity": "sha1-3vm9A86g+bcig9rA7CLSicdpEGk=",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-        "@babel/plugin-transform-parameters": "^7.10.4"
+        "@babel/plugin-transform-parameters": "^7.12.1"
       }
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
       "integrity": "sha1-qYP7Gusuw/btBCohD2QOkOeG/g0=",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -329,7 +316,7 @@
     },
     "@babel/plugin-syntax-dynamic-import": {
       "version": "7.8.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
       "integrity": "sha1-Yr+Ysto80h1iYVT8lu5bPLaOrLM=",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -337,7 +324,7 @@
     },
     "@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
       "integrity": "sha1-7mATSMNw+jNNIge+FYd3SWUh/VE=",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -345,240 +332,238 @@
     },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.8.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
       "integrity": "sha1-YOIl7cvZimQDMqLnLdPmbxr1WHE=",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
     "@babel/plugin-transform-arrow-functions": {
-      "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.4.tgz",
-      "integrity": "sha1-4ilg135pfHT0HFAdRNc9v4pqZM0=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.12.1.tgz",
+      "integrity": "sha1-gIP/yGrI53f74ktZZ8SyUh88srM=",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
-      "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.10.4.tgz",
-      "integrity": "sha1-QaUBfknrbzzak5KlHu8pQFskWjc=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.12.1.tgz",
+      "integrity": "sha1-OEmknMKiLpdDy9a1KSbTAzcimvE=",
       "requires": {
-        "@babel/helper-module-imports": "^7.10.4",
+        "@babel/helper-module-imports": "^7.12.1",
         "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/helper-remap-async-to-generator": "^7.10.4"
+        "@babel/helper-remap-async-to-generator": "^7.12.1"
       }
     },
     "@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.4.tgz",
-      "integrity": "sha1-GvpZV0T3XkOpGvc7DZmOz+Trwug=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.12.1.tgz",
+      "integrity": "sha1-8qGjZb3itxEuCm3tkGf918B5Bdk=",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.11.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.11.1.tgz",
-      "integrity": "sha1-W37+mIUr741lLAsoFEzZOp5LUhU=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.1.tgz",
+      "integrity": "sha1-8O5yeHS0KiCKSKWGuEw9IiwrvvE=",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.4.tgz",
-      "integrity": "sha1-QFE2rys+IYvEoZJiKLyRerGgrcc=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-classes/-/plugin-transform-classes-7.12.1.tgz",
+      "integrity": "sha1-ZeZQ/K3dPYjdzmfA+DSj1DajLbY=",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.10.4",
         "@babel/helper-define-map": "^7.10.4",
         "@babel/helper-function-name": "^7.10.4",
         "@babel/helper-optimise-call-expression": "^7.10.4",
         "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/helper-replace-supers": "^7.10.4",
+        "@babel/helper-replace-supers": "^7.12.1",
         "@babel/helper-split-export-declaration": "^7.10.4",
         "globals": "^11.1.0"
       },
       "dependencies": {
         "globals": {
           "version": "11.12.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/globals/-/globals-11.12.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/globals/-/globals-11.12.0.tgz",
           "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4="
         }
       }
     },
     "@babel/plugin-transform-computed-properties": {
-      "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.4.tgz",
-      "integrity": "sha1-ne2DqBboLe0o1S1LTsvdgQzfwOs=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.12.1.tgz",
+      "integrity": "sha1-1oz2ybf4OKikFEutvpdUHqCQSFI=",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.4.tgz",
-      "integrity": "sha1-cN3Ss9G+qD0BUJ6bsl3bOnT8heU=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.12.1.tgz",
+      "integrity": "sha1-uaVw/g0KjUYBFkE8tPl+jgiy+Ec=",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
-      "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.10.4.tgz",
-      "integrity": "sha1-aX5Qyf7hQ4D+hD0fMGspVhdDHkc=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.12.1.tgz",
+      "integrity": "sha1-dFZhuropWsBuaGgieXpp+6osoig=",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.10.4.tgz",
-      "integrity": "sha1-WuM4xX+M9AAb2zVgeuZrktZlry4=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.12.1.tgz",
+      "integrity": "sha1-sPLtNWuhvhQo7K8Sj/iiTwKDCuA=",
       "requires": {
         "@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.4",
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.4.tgz",
-      "integrity": "sha1-wIiS6IGdOl2ykDGxFa9RHbv+uuk=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.12.1.tgz",
+      "integrity": "sha1-B2QPKIZ+0W+VEcmciIKR9WCSHPo=",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-function-name": {
-      "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.10.4.tgz",
-      "integrity": "sha1-akZ4gOD8ljhRS6NpERgR3b4mRLc=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.12.1.tgz",
+      "integrity": "sha1-LsdiWMcP4IxtfaFUADpIBiDrpmc=",
       "requires": {
         "@babel/helper-function-name": "^7.10.4",
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-instanceof": {
-      "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-instanceof/-/plugin-transform-instanceof-7.10.4.tgz",
-      "integrity": "sha1-BdrZNPJuiHwACfZoWm4U/dliEgs=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-instanceof/-/plugin-transform-instanceof-7.12.1.tgz",
+      "integrity": "sha1-CF3FFgOEor3JTC9RFY+rd7cOpz8=",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-literals": {
-      "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.4.tgz",
-      "integrity": "sha1-n0K6CEEQChNfInEtDjkcRi9XHzw=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-literals/-/plugin-transform-literals-7.12.1.tgz",
+      "integrity": "sha1-1zuAOiazcBfd+dO7j03Fi/uAb1c=",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-modules-amd": {
-      "version": "7.10.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.5.tgz",
-      "integrity": "sha1-G5zdrwXZ6Is6rTOcs+RFxPAgqbE=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.12.1.tgz",
+      "integrity": "sha1-MVQwCwJhhWZu67DA7X+EFf789vk=",
       "requires": {
-        "@babel/helper-module-transforms": "^7.10.5",
+        "@babel/helper-module-transforms": "^7.12.1",
         "@babel/helper-plugin-utils": "^7.10.4",
         "babel-plugin-dynamic-import-node": "^2.3.3"
       }
     },
     "@babel/plugin-transform-object-super": {
-      "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.4.tgz",
-      "integrity": "sha1-1xRsTROUM+emUm+IjGZ+MUoJOJQ=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.12.1.tgz",
+      "integrity": "sha1-TqCGlrjS5lhB0MdwZIKwSL7RBm4=",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/helper-replace-supers": "^7.10.4"
+        "@babel/helper-replace-supers": "^7.12.1"
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.10.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.5.tgz",
-      "integrity": "sha1-WdM51Y0LGVBDX0BD504lEABeLEo=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.12.1.tgz",
+      "integrity": "sha1-0uljsDh3FlDJIu/1k3mclthTJV0=",
       "requires": {
-        "@babel/helper-get-function-arity": "^7.10.4",
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.4.tgz",
-      "integrity": "sha1-IBXlnYOQdOdoON4hWdtCGWb9i2M=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.12.1.tgz",
+      "integrity": "sha1-Xwoo2EL2RiKB8GqWToi6jXq0l1M=",
       "requires": {
         "regenerator-transform": "^0.14.2"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
-      "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.4.tgz",
-      "integrity": "sha1-n9Jexc3VVbt/Rz5ebuHJce7eTdY=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.1.tgz",
+      "integrity": "sha1-C/nKxVUPzgz98ENCD2YdZF/cdeM=",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-spread": {
-      "version": "7.11.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-spread/-/plugin-transform-spread-7.11.0.tgz",
-      "integrity": "sha1-+oTTAPXk9XdS/kGm0bPFVPE/F8w=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-spread/-/plugin-transform-spread-7.12.1.tgz",
+      "integrity": "sha1-Un+fMRvk7H/cK3m7ife/iEs+Hh4=",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.11.0"
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
-      "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.10.4.tgz",
-      "integrity": "sha1-jziJ7oZXWBEwop2cyR18c7fEoo0=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.1.tgz",
+      "integrity": "sha1-XCTPUN45bTDpmvyNHHAOi84PXK8=",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4",
         "@babel/helper-regex": "^7.10.4"
       }
     },
     "@babel/plugin-transform-template-literals": {
-      "version": "7.10.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.5.tgz",
-      "integrity": "sha1-eLxdYmpmQtszEtnQ8AH152Of3ow=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.12.1.tgz",
+      "integrity": "sha1-tD7ObtmnnAxxEZ9XbSme8J2UKEM=",
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.10.4",
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
-      "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.10.4.tgz",
-      "integrity": "sha1-lQnxp+7DHE7b/+E3wWzDP/C8W/w=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.1.tgz",
+      "integrity": "sha1-nKa+ND1CUS+8LmgjaoKuZLx694o=",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
-      "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.10.4.tgz",
-      "integrity": "sha1-5W1x+SgvrG2wnIJ0IFVXbV5tgKg=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.12.1.tgz",
+      "integrity": "sha1-zJZh9hOQ21xl4/66zO/Vxqw/rss=",
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+        "@babel/helper-create-regexp-features-plugin": "^7.12.1",
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/runtime": {
-      "version": "7.11.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/runtime/-/runtime-7.11.2.tgz",
-      "integrity": "sha1-9UnBPHVMxAuHZEufqfCaapX+BzY=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/runtime/-/runtime-7.12.1.tgz",
+      "integrity": "sha1-tBFqa2cR0BCy2tO3tuQ78bmVR0A=",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       },
       "dependencies": {
         "regenerator-runtime": {
           "version": "0.13.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
           "integrity": "sha1-ysLazIoepnX+qrrriugziYrkb1U="
         }
       }
     },
     "@babel/template": {
       "version": "7.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/template/-/template-7.10.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/template/-/template-7.10.4.tgz",
       "integrity": "sha1-MlGZbEIA68cdGo/EBfupQPNrong=",
       "requires": {
         "@babel/code-frame": "^7.10.4",
@@ -587,45 +572,32 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.11.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/traverse/-/traverse-7.11.5.tgz",
-      "integrity": "sha1-vnd7k7UY62127i4eodFD2qEeYcM=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/traverse/-/traverse-7.12.1.tgz",
+      "integrity": "sha1-lBOV4MXMhtXT51yqCV05JFJvDB4=",
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.11.5",
+        "@babel/generator": "^7.12.1",
         "@babel/helper-function-name": "^7.10.4",
         "@babel/helper-split-export-declaration": "^7.11.0",
-        "@babel/parser": "^7.11.5",
-        "@babel/types": "^7.11.5",
+        "@babel/parser": "^7.12.1",
+        "@babel/types": "^7.12.1",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.19"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
         "globals": {
           "version": "11.12.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/globals/-/globals-11.12.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/globals/-/globals-11.12.0.tgz",
           "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4="
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         }
       }
     },
     "@babel/types": {
-      "version": "7.11.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/types/-/types-7.11.5.tgz",
-      "integrity": "sha1-2d5XfQElLXfGgAzuA57mT691Zi0=",
+      "version": "7.12.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/types/-/types-7.12.1.tgz",
+      "integrity": "sha1-4QnZq5mo3nNb4ofuPWqZR6GQxK4=",
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.4",
         "lodash": "^4.17.19",
@@ -634,7 +606,7 @@
     },
     "@dabh/diagnostics": {
       "version": "2.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
       "integrity": "sha1-KQ0I97OBuPlGB9yPRxoSxnX52zE=",
       "requires": {
         "colorspace": "1.1.x",
@@ -644,7 +616,7 @@
     },
     "@eslint/eslintrc": {
       "version": "0.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@eslint/eslintrc/-/eslintrc-0.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@eslint/eslintrc/-/eslintrc-0.1.3.tgz",
       "integrity": "sha1-fRorI1hVLMBINMCXm9QnU2LjcIU=",
       "requires": {
         "ajv": "^6.12.4",
@@ -659,29 +631,16 @@
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
         "ignore": {
           "version": "4.0.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ignore/-/ignore-4.0.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw="
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         }
       }
     },
     "@govflanders/vl-ui-accordion": {
       "version": "3.11.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-accordion/vl-ui-accordion-3.11.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@govflanders/vl-ui-accordion/vl-ui-accordion-3.11.5.tgz",
       "integrity": "sha1-+/nKNOG15zl3/Yqixc1ILRFF6fg=",
       "requires": {
         "@govflanders/vl-ui-button": "^3.11.5",
@@ -695,7 +654,7 @@
     },
     "@govflanders/vl-ui-action-group": {
       "version": "3.11.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-action-group/vl-ui-action-group-3.11.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@govflanders/vl-ui-action-group/vl-ui-action-group-3.11.5.tgz",
       "integrity": "sha1-OAAbzIdOiUj6tuI+9KZOmPJYLwo=",
       "requires": {
         "@govflanders/vl-ui-button": "^3.11.5",
@@ -706,7 +665,7 @@
     },
     "@govflanders/vl-ui-button": {
       "version": "3.11.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-button/vl-ui-button-3.11.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@govflanders/vl-ui-button/vl-ui-button-3.11.5.tgz",
       "integrity": "sha1-vI8XFbd0xiqTyPp2W29Dt4WYvz8=",
       "requires": {
         "@govflanders/vl-ui-core": "^4.0.5",
@@ -716,7 +675,7 @@
     },
     "@govflanders/vl-ui-code-preview": {
       "version": "3.11.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-code-preview/vl-ui-code-preview-3.11.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@govflanders/vl-ui-code-preview/vl-ui-code-preview-3.11.5.tgz",
       "integrity": "sha1-bVltkDh8lIJaEEsGmDtgsyQSobQ=",
       "requires": {
         "@govflanders/vl-ui-button": "^3.11.5",
@@ -730,7 +689,7 @@
     },
     "@govflanders/vl-ui-core": {
       "version": "4.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-core/vl-ui-core-4.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@govflanders/vl-ui-core/vl-ui-core-4.0.5.tgz",
       "integrity": "sha1-Wjg9yeCNQriLbKHeow/hJutbnCc=",
       "requires": {
         "@govflanders/vl-ui-util": "^3.11.5",
@@ -744,7 +703,7 @@
     },
     "@govflanders/vl-ui-datepicker": {
       "version": "3.11.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-datepicker/vl-ui-datepicker-3.11.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@govflanders/vl-ui-datepicker/vl-ui-datepicker-3.11.5.tgz",
       "integrity": "sha1-x3hXvAsv/8wDkf7OJk0fl+TGwEc=",
       "requires": {
         "@govflanders/vl-ui-core": "^4.0.5",
@@ -758,7 +717,7 @@
     },
     "@govflanders/vl-ui-form-message": {
       "version": "3.11.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-form-message/vl-ui-form-message-3.11.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@govflanders/vl-ui-form-message/vl-ui-form-message-3.11.5.tgz",
       "integrity": "sha1-M5hTCSwjBsqTYMBQUBQh7jilW5I=",
       "requires": {
         "@govflanders/vl-ui-core": "^4.0.5",
@@ -767,7 +726,7 @@
     },
     "@govflanders/vl-ui-form-structure": {
       "version": "3.11.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-form-structure/vl-ui-form-structure-3.11.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@govflanders/vl-ui-form-structure/vl-ui-form-structure-3.11.5.tgz",
       "integrity": "sha1-BaWrQFD4FnEFm9LImZDzJMK4zOk=",
       "requires": {
         "@govflanders/vl-ui-action-group": "^3.11.5",
@@ -781,7 +740,7 @@
     },
     "@govflanders/vl-ui-form-validation": {
       "version": "4.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-form-validation/vl-ui-form-validation-4.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@govflanders/vl-ui-form-validation/vl-ui-form-validation-4.0.6.tgz",
       "integrity": "sha1-7f80dOWux8aYpMByHrxzwQebPZY=",
       "requires": {
         "@govflanders/vl-ui-button": "^3.11.5",
@@ -803,14 +762,14 @@
       "dependencies": {
         "promise-polyfill": {
           "version": "8.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
           "integrity": "sha1-jJmzz1PzqRxoIm/9573oHX+QQRY="
         }
       }
     },
     "@govflanders/vl-ui-icon": {
       "version": "3.11.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-icon/vl-ui-icon-3.11.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@govflanders/vl-ui-icon/vl-ui-icon-3.11.5.tgz",
       "integrity": "sha1-3a2Q/CBQbp8K0yrkKdO0iZsZ5XE=",
       "requires": {
         "@govflanders/vl-ui-core": "^4.0.5",
@@ -819,7 +778,7 @@
     },
     "@govflanders/vl-ui-infotext": {
       "version": "3.11.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-infotext/vl-ui-infotext-3.11.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@govflanders/vl-ui-infotext/vl-ui-infotext-3.11.5.tgz",
       "integrity": "sha1-f4NvFB08orDZTWqsNfqqUa5NIwE=",
       "requires": {
         "@govflanders/vl-ui-core": "^4.0.5",
@@ -829,7 +788,7 @@
     },
     "@govflanders/vl-ui-input-addon": {
       "version": "3.11.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-input-addon/vl-ui-input-addon-3.11.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@govflanders/vl-ui-input-addon/vl-ui-input-addon-3.11.5.tgz",
       "integrity": "sha1-2HkC/SmU9xjOk5E8nqWLLiPcV8o=",
       "requires": {
         "@govflanders/vl-ui-core": "^4.0.5",
@@ -840,7 +799,7 @@
     },
     "@govflanders/vl-ui-input-field": {
       "version": "3.11.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-input-field/vl-ui-input-field-3.11.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@govflanders/vl-ui-input-field/vl-ui-input-field-3.11.5.tgz",
       "integrity": "sha1-XPGjcav9FBi8Fus77cw0l5YU33M=",
       "requires": {
         "@govflanders/vl-ui-button": "^3.11.5",
@@ -851,7 +810,7 @@
     },
     "@govflanders/vl-ui-input-group": {
       "version": "3.11.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-input-group/vl-ui-input-group-3.11.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@govflanders/vl-ui-input-group/vl-ui-input-group-3.11.5.tgz",
       "integrity": "sha1-UldB7peSw9DnD4o1R1IA+LmkMQQ=",
       "requires": {
         "@govflanders/vl-ui-button": "^3.11.5",
@@ -866,7 +825,7 @@
     },
     "@govflanders/vl-ui-link": {
       "version": "3.11.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-link/vl-ui-link-3.11.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@govflanders/vl-ui-link/vl-ui-link-3.11.5.tgz",
       "integrity": "sha1-vEEvbB8YpntoSYX41q1Xu83yAOc=",
       "requires": {
         "@govflanders/vl-ui-core": "^4.0.5",
@@ -876,7 +835,7 @@
     },
     "@govflanders/vl-ui-multiselect": {
       "version": "3.11.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-multiselect/vl-ui-multiselect-3.11.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@govflanders/vl-ui-multiselect/vl-ui-multiselect-3.11.5.tgz",
       "integrity": "sha1-TNOVKOc6nRKMOJPRsmmJGEXYapk=",
       "requires": {
         "@govflanders/vl-ui-core": "^4.0.5",
@@ -892,7 +851,7 @@
     },
     "@govflanders/vl-ui-pattern": {
       "version": "3.11.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-pattern/vl-ui-pattern-3.11.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@govflanders/vl-ui-pattern/vl-ui-pattern-3.11.5.tgz",
       "integrity": "sha1-tdOuqatfAglC7FAS3EeKIrqjpno=",
       "requires": {
         "@govflanders/vl-ui-core": "^4.0.5",
@@ -907,7 +866,7 @@
     },
     "@govflanders/vl-ui-pill": {
       "version": "3.11.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-pill/vl-ui-pill-3.11.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@govflanders/vl-ui-pill/vl-ui-pill-3.11.5.tgz",
       "integrity": "sha1-yYtn473ZzHfV4DOcnWQM4BWD9c8=",
       "requires": {
         "@govflanders/vl-ui-core": "^4.0.5",
@@ -916,7 +875,7 @@
     },
     "@govflanders/vl-ui-pill-input": {
       "version": "3.11.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-pill-input/vl-ui-pill-input-3.11.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@govflanders/vl-ui-pill-input/vl-ui-pill-input-3.11.5.tgz",
       "integrity": "sha1-3Qej3cdxm5yyV55gwyWAWCfCjQg=",
       "requires": {
         "@govflanders/vl-ui-core": "^4.0.5",
@@ -930,7 +889,7 @@
       "dependencies": {
         "choices.js": {
           "version": "7.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/choices.js/-/choices.js-7.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/choices.js/-/choices.js-7.0.0.tgz",
           "integrity": "sha1-jbT/i6r/rF4yGWDb+K65UZ9YNRw=",
           "requires": {
             "classnames": "^2.2.6",
@@ -941,14 +900,14 @@
         },
         "fuse.js": {
           "version": "3.4.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fuse.js/-/fuse.js-3.4.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fuse.js/-/fuse.js-3.4.2.tgz",
           "integrity": "sha1-16Y4xDbs17nEwAUUeMCVlOuVYhI="
         }
       }
     },
     "@govflanders/vl-ui-progress-bar": {
       "version": "3.11.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-progress-bar/vl-ui-progress-bar-3.11.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@govflanders/vl-ui-progress-bar/vl-ui-progress-bar-3.11.5.tgz",
       "integrity": "sha1-RaPJi5XA6jTHxBVy0YSaX8iQTDM=",
       "requires": {
         "@govflanders/vl-ui-core": "^4.0.5",
@@ -958,7 +917,7 @@
     },
     "@govflanders/vl-ui-select": {
       "version": "3.11.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-select/vl-ui-select-3.11.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@govflanders/vl-ui-select/vl-ui-select-3.11.5.tgz",
       "integrity": "sha1-bUOt/hNzqErHFccDqVPxzl2dnrs=",
       "requires": {
         "@govflanders/vl-ui-core": "^4.0.5",
@@ -970,7 +929,7 @@
     },
     "@govflanders/vl-ui-toggle": {
       "version": "3.11.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-toggle/vl-ui-toggle-3.11.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@govflanders/vl-ui-toggle/vl-ui-toggle-3.11.5.tgz",
       "integrity": "sha1-heIGJl8pTzbNgKkgVtE020Pv+FQ=",
       "requires": {
         "@govflanders/vl-ui-accordion": "^3.11.5",
@@ -984,7 +943,7 @@
     },
     "@govflanders/vl-ui-tooltip": {
       "version": "3.11.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-tooltip/vl-ui-tooltip-3.11.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@govflanders/vl-ui-tooltip/vl-ui-tooltip-3.11.5.tgz",
       "integrity": "sha1-8tKHuX3fKhAsesqzSFfPFRfZt/A=",
       "requires": {
         "@govflanders/vl-ui-button": "^3.11.5",
@@ -995,7 +954,7 @@
     },
     "@govflanders/vl-ui-util": {
       "version": "3.11.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-util/vl-ui-util-3.11.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@govflanders/vl-ui-util/vl-ui-util-3.11.5.tgz",
       "integrity": "sha1-lmaCBkJwE1rLheGZUSgCoSDvSGc=",
       "requires": {
         "@govflanders/vl-ui-core": "^4.0.5",
@@ -1007,35 +966,20 @@
     },
     "@kwsites/file-exists": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
       "integrity": "sha1-rR78rBPhmH2NuvI17zvlsNlvqpk=",
       "requires": {
         "debug": "^4.1.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
-        }
       }
     },
     "@kwsites/promise-deferred": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
       "integrity": "sha1-is5SWSVEJszvV/MXW8ZO1wle2Rk="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
       "integrity": "sha1-Olgr21OATGum0UZXnEblITDPSjs=",
       "requires": {
         "@nodelib/fs.stat": "2.0.3",
@@ -1044,12 +988,12 @@
     },
     "@nodelib/fs.stat": {
       "version": "2.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
       "integrity": "sha1-NNxfTKu8cg9OYPdadH5+zWwXW9M="
     },
     "@nodelib/fs.walk": {
       "version": "1.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
       "integrity": "sha1-ARuSAqcKY2bkNspcBlhEUoqwSXY=",
       "requires": {
         "@nodelib/fs.scandir": "2.1.3",
@@ -1058,12 +1002,12 @@
     },
     "@polymer/esm-amd-loader": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@polymer/esm-amd-loader/-/esm-amd-loader-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@polymer/esm-amd-loader/-/esm-amd-loader-1.0.4.tgz",
       "integrity": "sha1-Tnfy9ZspsB4K0CqoPTNxbN3F+fk="
     },
     "@polymer/polymer": {
       "version": "3.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@polymer/polymer/-/polymer-3.4.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@polymer/polymer/-/polymer-3.4.1.tgz",
       "integrity": "sha1-MzvvJXEfhBG7ViT7PrqCEu+L7pY=",
       "requires": {
         "@webcomponents/shadycss": "^1.9.1"
@@ -1071,17 +1015,17 @@
     },
     "@polymer/sinonjs": {
       "version": "1.17.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@polymer/sinonjs/-/sinonjs-1.17.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@polymer/sinonjs/-/sinonjs-1.17.1.tgz",
       "integrity": "sha1-5H03hbfQ6MKf65f36SSw/Fl+Lps="
     },
     "@polymer/test-fixture": {
       "version": "3.0.0-pre.21",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@polymer/test-fixture/-/test-fixture-3.0.0-pre.21.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@polymer/test-fixture/-/test-fixture-3.0.0-pre.21.tgz",
       "integrity": "sha1-hRUiB8sL9XyuvBkcgLsP22lSYU4="
     },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
       "integrity": "sha1-ohEXsZ7pvnDDeewYd1N+8uHGMwE=",
       "requires": {
         "any-observable": "^0.3.0"
@@ -1089,19 +1033,19 @@
       "dependencies": {
         "any-observable": {
           "version": "0.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/any-observable/-/any-observable-0.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/any-observable/-/any-observable-0.3.0.tgz",
           "integrity": "sha1-r5M0deWAamfQ198JDdXovvZdEZs="
         }
       }
     },
     "@sindresorhus/is": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@sindresorhus/is/-/is-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@sindresorhus/is/-/is-2.1.1.tgz",
       "integrity": "sha1-zv9qKKW0hnwt1KG6UT3ieMy+i7E="
     },
     "@sinonjs/commons": {
       "version": "1.8.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@sinonjs/commons/-/commons-1.8.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@sinonjs/commons/-/commons-1.8.1.tgz",
       "integrity": "sha1-598A+YogMyT23HzGBsrZ1KirIhc=",
       "requires": {
         "type-detect": "4.0.8"
@@ -1109,7 +1053,7 @@
     },
     "@sinonjs/fake-timers": {
       "version": "6.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
       "integrity": "sha1-KTZ0/MsyYqx4LHqt/eyoaxDHXEA=",
       "requires": {
         "@sinonjs/commons": "^1.7.0"
@@ -1117,7 +1061,7 @@
     },
     "@sinonjs/formatio": {
       "version": "5.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@sinonjs/formatio/-/formatio-5.0.1.tgz",
       "integrity": "sha1-8T5xPLMxOxq5ZZAbAbCCjqa3cIk=",
       "requires": {
         "@sinonjs/commons": "^1",
@@ -1125,9 +1069,9 @@
       }
     },
     "@sinonjs/samsam": {
-      "version": "5.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@sinonjs/samsam/-/samsam-5.1.0.tgz",
-      "integrity": "sha1-Ov5xkjK1Qbts80EaTDmaGI3iHsA=",
+      "version": "5.2.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@sinonjs/samsam/-/samsam-5.2.0.tgz",
+      "integrity": "sha1-/P+Dq4b4O1SY9KlnhpwHlAjZtes=",
       "requires": {
         "@sinonjs/commons": "^1.6.0",
         "lodash.get": "^4.4.2",
@@ -1136,12 +1080,12 @@
     },
     "@sinonjs/text-encoding": {
       "version": "0.7.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha1-jaXGUwkVZT86Hzj9XxAdjD+AecU="
     },
     "@szmarczak/http-timer": {
       "version": "4.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
       "integrity": "sha1-v71QIR6d+lG6B9pYoUzf0zMgUVI=",
       "requires": {
         "defer-to-connect": "^2.0.0"
@@ -1149,12 +1093,12 @@
     },
     "@testim/chrome-version": {
       "version": "1.0.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@testim/chrome-version/-/chrome-version-1.0.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@testim/chrome-version/-/chrome-version-1.0.7.tgz",
       "integrity": "sha1-DNkVeF7EGQ8Io6asybYfw4+18ak="
     },
     "@types/babel-generator": {
       "version": "6.25.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/babel-generator/-/babel-generator-6.25.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/babel-generator/-/babel-generator-6.25.3.tgz",
       "integrity": "sha1-jwbKoS0FlaBThWCr53GWbXfSkoY=",
       "requires": {
         "@types/babel-types": "*"
@@ -1162,7 +1106,7 @@
     },
     "@types/babel-traverse": {
       "version": "6.25.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/babel-traverse/-/babel-traverse-6.25.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/babel-traverse/-/babel-traverse-6.25.5.tgz",
       "integrity": "sha1-bSk891I+SLUk+qe4bcPEiBkUhOU=",
       "requires": {
         "@types/babel-types": "*"
@@ -1170,12 +1114,12 @@
     },
     "@types/babel-types": {
       "version": "6.25.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/babel-types/-/babel-types-6.25.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/babel-types/-/babel-types-6.25.2.tgz",
       "integrity": "sha1-XFf0WXPk8TdC28UnPdhM/+c3Op4="
     },
     "@types/babylon": {
       "version": "6.16.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/babylon/-/babylon-6.16.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/babylon/-/babylon-6.16.5.tgz",
       "integrity": "sha1-HFZB22nrjN83jt0ltL53VL7rSLQ=",
       "requires": {
         "@types/babel-types": "*"
@@ -1183,12 +1127,12 @@
     },
     "@types/bluebird": {
       "version": "3.5.32",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/bluebird/-/bluebird-3.5.32.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/bluebird/-/bluebird-3.5.32.tgz",
       "integrity": "sha1-OB57WeOfAQ0gu/fgROSPXK8atiA="
     },
     "@types/body-parser": {
       "version": "1.19.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/body-parser/-/body-parser-1.19.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/body-parser/-/body-parser-1.19.0.tgz",
       "integrity": "sha1-BoWzxH6zAG/+0RfN1VFkth+AU48=",
       "requires": {
         "@types/connect": "*",
@@ -1197,7 +1141,7 @@
     },
     "@types/cacheable-request": {
       "version": "6.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
       "integrity": "sha1-XSLz3e0f06hMC761A5p0GcLJGXY=",
       "requires": {
         "@types/http-cache-semantics": "*",
@@ -1207,13 +1151,13 @@
       }
     },
     "@types/chai": {
-      "version": "4.2.12",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/chai/-/chai-4.2.12.tgz",
-      "integrity": "sha1-YWCuRUzYna4FrcO7l5l/SItgggE="
+      "version": "4.2.14",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/chai/-/chai-4.2.14.tgz",
+      "integrity": "sha1-RNLdC13mGFCJN12Xa07FyvaGEZM="
     },
     "@types/chai-subset": {
       "version": "1.3.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/chai-subset/-/chai-subset-1.3.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/chai-subset/-/chai-subset-1.3.3.tgz",
       "integrity": "sha1-l4k4FOkqvSxTTeQiyzd+DgvarJQ=",
       "requires": {
         "@types/chai": "*"
@@ -1221,12 +1165,12 @@
     },
     "@types/chalk": {
       "version": "0.4.31",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/chalk/-/chalk-0.4.31.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/chalk/-/chalk-0.4.31.tgz",
       "integrity": "sha1-ox10JBprHtu5c8822XooloNKUfk="
     },
     "@types/clean-css": {
       "version": "4.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/clean-css/-/clean-css-4.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/clean-css/-/clean-css-4.2.2.tgz",
       "integrity": "sha1-mf159pOcKzJZOKHFaXEuB92X1wk=",
       "requires": {
         "@types/node": "*"
@@ -1234,17 +1178,12 @@
     },
     "@types/clone": {
       "version": "0.1.30",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/clone/-/clone-0.1.30.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/clone/-/clone-0.1.30.tgz",
       "integrity": "sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ="
-    },
-    "@types/color-name": {
-      "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha1-HBJhu+qhCoBVu8XYq4S3sq/IRqA="
     },
     "@types/compression": {
       "version": "0.0.33",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/compression/-/compression-0.0.33.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/compression/-/compression-0.0.33.tgz",
       "integrity": "sha1-ldxzOiM5qoRjgdfxN3eS0lU9wn0=",
       "requires": {
         "@types/express": "*"
@@ -1252,7 +1191,7 @@
     },
     "@types/connect": {
       "version": "3.4.33",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/connect/-/connect-3.4.33.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/connect/-/connect-3.4.33.tgz",
       "integrity": "sha1-MWEMkB7KVzuHE8MzCrxua59YhUY=",
       "requires": {
         "@types/node": "*"
@@ -1260,37 +1199,37 @@
     },
     "@types/content-type": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/content-type/-/content-type-1.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/content-type/-/content-type-1.1.3.tgz",
       "integrity": "sha1-Noi9d/wS+TVUju8QKk40xRKwOgc="
     },
     "@types/cssbeautify": {
       "version": "0.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/cssbeautify/-/cssbeautify-0.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/cssbeautify/-/cssbeautify-0.3.1.tgz",
       "integrity": "sha1-jgvuj33suVIlDaDK6+BeMFkcF+8="
     },
     "@types/doctrine": {
       "version": "0.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/doctrine/-/doctrine-0.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/doctrine/-/doctrine-0.0.1.tgz",
       "integrity": "sha1-uZny2fe0PKvgoaLzm8IDvH3K2p0="
     },
     "@types/escape-html": {
       "version": "0.0.20",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/escape-html/-/escape-html-0.0.20.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/escape-html/-/escape-html-0.0.20.tgz",
       "integrity": "sha1-yuaYcU3WHr7lqz8q65o0uhARc1o="
     },
     "@types/estree": {
       "version": "0.0.45",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/estree/-/estree-0.0.45.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/estree/-/estree-0.0.45.tgz",
       "integrity": "sha1-6Th1cpmOXs2sIhlQ2rPow7Fq+IQ="
     },
     "@types/expect": {
       "version": "1.20.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/expect/-/expect-1.20.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/expect/-/expect-1.20.4.tgz",
       "integrity": "sha1-gojlFze/fjq118d7+mlYg3RSZOU="
     },
     "@types/express": {
       "version": "4.17.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/express/-/express-4.17.8.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/express/-/express-4.17.8.tgz",
       "integrity": "sha1-PfQpMpMxfmHGATfSc6LpbNjV8no=",
       "requires": {
         "@types/body-parser": "*",
@@ -1300,9 +1239,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.12",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/express-serve-static-core/-/express-serve-static-core-4.17.12.tgz",
-      "integrity": "sha1-mkh9p1dCXk8mfn0cVyAiavf4lZE=",
+      "version": "4.17.13",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/express-serve-static-core/-/express-serve-static-core-4.17.13.tgz",
+      "integrity": "sha1-2a8CXpJfyLCJvjdCO40erHgb4IQ=",
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -1311,13 +1250,13 @@
     },
     "@types/freeport": {
       "version": "1.0.21",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/freeport/-/freeport-1.0.21.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/freeport/-/freeport-1.0.21.tgz",
       "integrity": "sha1-c/ZUPtZ9PKP/+XuYVZFZi3CSBm8=",
       "optional": true
     },
     "@types/glob": {
       "version": "7.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/glob/-/glob-7.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/glob/-/glob-7.1.3.tgz",
       "integrity": "sha1-5rqA82t9qtLGhazZJmOC5omFwYM=",
       "requires": {
         "@types/minimatch": "*",
@@ -1326,7 +1265,7 @@
     },
     "@types/glob-stream": {
       "version": "6.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/glob-stream/-/glob-stream-6.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/glob-stream/-/glob-stream-6.1.0.tgz",
       "integrity": "sha1-ft6KM+WRQFNPjYrfuKye37MYl7w=",
       "requires": {
         "@types/glob": "*",
@@ -1335,7 +1274,7 @@
     },
     "@types/gulp-if": {
       "version": "0.0.33",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/gulp-if/-/gulp-if-0.0.33.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/gulp-if/-/gulp-if-0.0.33.tgz",
       "integrity": "sha1-7eziK3kl2abbX5yMDXiCqndvtng=",
       "requires": {
         "@types/node": "*",
@@ -1344,7 +1283,7 @@
     },
     "@types/html-minifier": {
       "version": "3.5.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/html-minifier/-/html-minifier-3.5.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/html-minifier/-/html-minifier-3.5.3.tgz",
       "integrity": "sha1-UnaEUTjbLOvFTHieCq+HYhoh6E8=",
       "requires": {
         "@types/clean-css": "*",
@@ -1354,17 +1293,17 @@
     },
     "@types/http-cache-semantics": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
       "integrity": "sha1-kUB3lzaqJlVjXudW4kZ9eHz+iio="
     },
     "@types/is-windows": {
       "version": "0.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/is-windows/-/is-windows-0.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/is-windows/-/is-windows-0.2.0.tgz",
       "integrity": "sha1-byTuSHMdMRaOpRBhDW3RXl/Jxv8="
     },
     "@types/keyv": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/keyv/-/keyv-3.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/keyv/-/keyv-3.1.1.tgz",
       "integrity": "sha1-5FpFMk/KnatxarEjDuJJyftSz6c=",
       "requires": {
         "@types/node": "*"
@@ -1372,28 +1311,28 @@
     },
     "@types/launchpad": {
       "version": "0.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/launchpad/-/launchpad-0.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/launchpad/-/launchpad-0.6.0.tgz",
       "integrity": "sha1-NylhCbfyd/bmxf1+DAcGvJGPu1E=",
       "optional": true
     },
     "@types/mime": {
       "version": "2.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/mime/-/mime-2.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/mime/-/mime-2.0.3.tgz",
       "integrity": "sha1-yJO3NyHbc2mZQ7/DZTsd63+qSjo="
     },
     "@types/minimatch": {
       "version": "3.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/minimatch/-/minimatch-3.0.3.tgz",
       "integrity": "sha1-PcoOPzOyAPx9ETnAzZbBJoyt/Z0="
     },
     "@types/minimist": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY="
     },
     "@types/mz": {
       "version": "0.0.29",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/mz/-/mz-0.0.29.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/mz/-/mz-0.0.29.tgz",
       "integrity": "sha1-vCRyjGSZc/HHhR6QM/nOUlZowns=",
       "requires": {
         "@types/bluebird": "*",
@@ -1401,18 +1340,18 @@
       }
     },
     "@types/node": {
-      "version": "14.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/node/-/node-14.10.1.tgz",
-      "integrity": "sha1-zDI7rY6KUz1IIvRc5OUybzbkIXc="
+      "version": "14.14.2",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/node/-/node-14.14.2.tgz",
+      "integrity": "sha1-0lKV+eTKWYmixhB1TcAqlyEjXus="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha1-5IbQ2XOW15vu3QpuM/RTT/a0lz4="
     },
     "@types/opn": {
       "version": "3.0.28",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/opn/-/opn-3.0.28.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/opn/-/opn-3.0.28.tgz",
       "integrity": "sha1-CX0NHJtXSVc6XZbfEyOHu20CEYo=",
       "requires": {
         "@types/node": "*"
@@ -1420,12 +1359,12 @@
     },
     "@types/parse-json": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-L4u0QUNNFjs1+4/9zNcTiSf/uMA="
     },
     "@types/parse5": {
       "version": "2.2.34",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/parse5/-/parse5-2.2.34.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/parse5/-/parse5-2.2.34.tgz",
       "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
       "requires": {
         "@types/node": "*"
@@ -1433,35 +1372,35 @@
     },
     "@types/path-is-inside": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/path-is-inside/-/path-is-inside-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/path-is-inside/-/path-is-inside-1.0.0.tgz",
       "integrity": "sha1-Atb/OJddaEveyWIESUuvnynw4X8="
     },
     "@types/pem": {
       "version": "1.9.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/pem/-/pem-1.9.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/pem/-/pem-1.9.5.tgz",
       "integrity": "sha1-zVVIteCstLQaniEGfp/NjFcInJk=",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/qs": {
-      "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/qs/-/qs-6.9.4.tgz",
-      "integrity": "sha1-pZ6FHBuhbAUT6hI4MN1jmgoVy2o="
+      "version": "6.9.5",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/qs/-/qs-6.9.5.tgz",
+      "integrity": "sha1-Q0cRvdSete5p2QwdZ8NUqajssYs="
     },
     "@types/range-parser": {
       "version": "1.2.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/range-parser/-/range-parser-1.2.3.tgz",
       "integrity": "sha1-fuMwunyq+5gJC+zoal7kQRWQTCw="
     },
     "@types/relateurl": {
       "version": "0.2.28",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/relateurl/-/relateurl-0.2.28.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/relateurl/-/relateurl-0.2.28.tgz",
       "integrity": "sha1-a9p9uGU/piZD9e5p6facEaOS46Y="
     },
     "@types/resolve": {
       "version": "0.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/resolve/-/resolve-0.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/resolve/-/resolve-0.0.6.tgz",
       "integrity": "sha1-C9LyNsLhzruYt5iF31ft1xqNdw4=",
       "requires": {
         "@types/node": "*"
@@ -1469,24 +1408,24 @@
     },
     "@types/responselike": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/responselike/-/responselike-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/responselike/-/responselike-1.0.0.tgz",
       "integrity": "sha1-JR9P59FU0rrRJavhtCmyOv0mLik=",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/serve-static": {
-      "version": "1.13.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/serve-static/-/serve-static-1.13.5.tgz",
-      "integrity": "sha1-PSXZQaGEFdOrCS3vhG4TWgi7z1M=",
+      "version": "1.13.6",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/serve-static/-/serve-static-1.13.6.tgz",
+      "integrity": "sha1-hmsbjexBw24ox75ArHJbiL5DxcE=",
       "requires": {
-        "@types/express-serve-static-core": "*",
-        "@types/mime": "*"
+        "@types/mime": "*",
+        "@types/node": "*"
       }
     },
     "@types/spdy": {
       "version": "3.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/spdy/-/spdy-3.4.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/spdy/-/spdy-3.4.4.tgz",
       "integrity": "sha1-MoL9StjEYDqkn3AX3VIKCKNFsrw=",
       "requires": {
         "@types/node": "*"
@@ -1494,25 +1433,25 @@
     },
     "@types/ua-parser-js": {
       "version": "0.7.33",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
       "integrity": "sha1-SpIIlRFXThKSiny2uZoBgxrNHdc="
     },
     "@types/uglify-js": {
-      "version": "3.9.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/uglify-js/-/uglify-js-3.9.3.tgz",
-      "integrity": "sha1-2U7WCOKVvFQkyWAOa4VlQHtrS2s=",
+      "version": "3.11.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/uglify-js/-/uglify-js-3.11.0.tgz",
+      "integrity": "sha1-KGjUBcxFzZ3DBpF5BSEDAywzr7w=",
       "requires": {
         "source-map": "^0.6.1"
       }
     },
     "@types/uuid": {
       "version": "3.4.9",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/uuid/-/uuid-3.4.9.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/uuid/-/uuid-3.4.9.tgz",
       "integrity": "sha1-/PAZl7vJ98Ca5fkTg68HbUZllOE="
     },
     "@types/vinyl": {
       "version": "2.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/vinyl/-/vinyl-2.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/vinyl/-/vinyl-2.0.4.tgz",
       "integrity": "sha1-mnqAccjRTTqV1B6+cTW6vkrVmVo=",
       "requires": {
         "@types/expect": "^1.20.4",
@@ -1521,7 +1460,7 @@
     },
     "@types/vinyl-fs": {
       "version": "2.4.11",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/vinyl-fs/-/vinyl-fs-2.4.11.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/vinyl-fs/-/vinyl-fs-2.4.11.tgz",
       "integrity": "sha1-uYEZuLsklBQer2SbCfv+sxEWEgY=",
       "requires": {
         "@types/glob-stream": "*",
@@ -1531,7 +1470,7 @@
     },
     "@types/whatwg-url": {
       "version": "6.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/whatwg-url/-/whatwg-url-6.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/whatwg-url/-/whatwg-url-6.4.0.tgz",
       "integrity": "sha1-Hlm4xkvA299m0DfPhEnRw9UnAjc=",
       "requires": {
         "@types/node": "*"
@@ -1539,42 +1478,52 @@
     },
     "@types/which": {
       "version": "1.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/which/-/which-1.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/which/-/which-1.3.2.tgz",
       "integrity": "sha1-nCRvwMk97TEchRLfKJH7QfYif98=",
       "optional": true
     },
     "@types/yauzl": {
       "version": "2.9.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/yauzl/-/yauzl-2.9.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/yauzl/-/yauzl-2.9.1.tgz",
       "integrity": "sha1-0Q9p+fUi7vPPmOMK+2hKHh7JI68=",
       "optional": true,
       "requires": {
         "@types/node": "*"
       }
     },
+    "@ungap/custom-elements": {
+      "version": "0.1.6",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@ungap/custom-elements/-/custom-elements-0.1.6.tgz",
+      "integrity": "sha1-4rjqUvzwe9dm5B1PZyK4Bads568="
+    },
+    "@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha1-qlgEJxHW4ydd033Fl+XTHowpCkQ="
+    },
     "@webcomponents/shadycss": {
-      "version": "1.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@webcomponents/shadycss/-/shadycss-1.10.1.tgz",
-      "integrity": "sha1-bzd7MTyWqTppDyUgazKiDq2ksqk="
+      "version": "1.10.2",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@webcomponents/shadycss/-/shadycss-1.10.2.tgz",
+      "integrity": "sha1-QOA8q23F4S8ZmUm6K3ngLxg9Hns="
     },
     "@webcomponents/webcomponentsjs": {
-      "version": "2.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.4.4.tgz",
-      "integrity": "sha1-FLfnjaR/jwBx/5bDUzW4cVNBebw="
+      "version": "2.5.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.5.0.tgz",
+      "integrity": "sha1-YbJ3haatW/1o+gGCAf5BixGMs40="
     },
     "abab": {
       "version": "2.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/abab/-/abab-2.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/abab/-/abab-2.0.5.tgz",
       "integrity": "sha1-wLZ4+zLWD8EhnHhNaoJv44Wut5o="
     },
     "abbrev": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/abbrev/-/abbrev-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg="
     },
     "accepts": {
       "version": "1.3.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/accepts/-/accepts-1.3.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/accepts/-/accepts-1.3.7.tgz",
       "integrity": "sha1-UxvHJlF6OytB+FACHGzBXqq1B80=",
       "requires": {
         "mime-types": "~2.1.24",
@@ -1583,17 +1532,17 @@
     },
     "accessibility-developer-tools": {
       "version": "2.12.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
       "integrity": "sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ="
     },
     "acorn": {
-      "version": "7.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn/-/acorn-7.4.0.tgz",
-      "integrity": "sha1-4a1IbmxUUBY0xsOXxcEh2qODYHw="
+      "version": "7.4.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo="
     },
     "acorn-globals": {
       "version": "6.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn-globals/-/acorn-globals-6.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/acorn-globals/-/acorn-globals-6.0.0.tgz",
       "integrity": "sha1-Rs3Tnw+P8IqHZhm1X1rIptx3C0U=",
       "requires": {
         "acorn": "^7.1.1",
@@ -1602,50 +1551,32 @@
     },
     "acorn-jsx": {
       "version": "5.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
       "integrity": "sha1-/IZh4Rt6wVOcR9v+oucrOvNNJns="
     },
     "acorn-walk": {
       "version": "7.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/acorn-walk/-/acorn-walk-7.2.0.tgz",
       "integrity": "sha1-DeiJpgEgOQmw++B7iTjcIdLpZ7w="
     },
     "adm-zip": {
       "version": "0.4.16",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/adm-zip/-/adm-zip-0.4.16.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/adm-zip/-/adm-zip-0.4.16.tgz",
       "integrity": "sha1-z0xQj9/6sCwmnLx/RxqHXwVXA2U="
     },
     "after": {
       "version": "0.8.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/after/-/after-0.8.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/after/-/after-0.8.2.tgz",
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
     },
     "agent-base": {
-      "version": "6.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/agent-base/-/agent-base-6.0.1.tgz",
-      "integrity": "sha1-gIAH5OWGfeywq2qy+Sj721pZbbQ=",
-      "requires": {
-        "debug": "4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
-        }
-      }
+      "version": "5.1.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/agent-base/-/agent-base-5.1.1.tgz",
+      "integrity": "sha1-6Ps/JClZ20TWO+Zl23qOc5U3oyw="
     },
     "aggregate-error": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/aggregate-error/-/aggregate-error-3.1.0.tgz",
       "integrity": "sha1-kmcP9Q9TWb23o+DUDQ7DDFc3aHo=",
       "requires": {
         "clean-stack": "^2.0.0",
@@ -1653,9 +1584,9 @@
       }
     },
     "ajv": {
-      "version": "6.12.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ajv/-/ajv-6.12.5.tgz",
-      "integrity": "sha1-GbDouuj0duW6ZmMAOHd1+xoApNo=",
+      "version": "6.12.6",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1665,7 +1596,7 @@
     },
     "ansi-align": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-align/-/ansi-align-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-align/-/ansi-align-3.0.0.tgz",
       "integrity": "sha1-tTazcc9ofKrvI2wY0+If43l0Z8s=",
       "requires": {
         "string-width": "^3.0.0"
@@ -1673,17 +1604,17 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "requires": {
             "emoji-regex": "^7.0.1",
@@ -1693,7 +1624,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -1703,12 +1634,12 @@
     },
     "ansi-colors": {
       "version": "4.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-colors/-/ansi-colors-4.1.1.tgz",
       "integrity": "sha1-y7muJWv3UK8eqzRPIpqif+lLo0g="
     },
     "ansi-escapes": {
       "version": "4.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
       "integrity": "sha1-pcR8xDGB8fOP/XB2g3cA05VSKmE=",
       "requires": {
         "type-fest": "^0.11.0"
@@ -1716,19 +1647,19 @@
       "dependencies": {
         "type-fest": {
           "version": "0.11.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.11.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.11.0.tgz",
           "integrity": "sha1-l6vwhyMQ/tiKXEZrJWgVdhReM/E="
         }
       }
     },
     "ansi-regex": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "3.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
       "requires": {
         "color-convert": "^1.9.0"
@@ -1736,17 +1667,17 @@
     },
     "any-observable": {
       "version": "0.5.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/any-observable/-/any-observable-0.5.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/any-observable/-/any-observable-0.5.1.tgz",
       "integrity": "sha1-q31J/2Tr5t064mdgo/WogejbeR4="
     },
     "any-promise": {
       "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/any-promise/-/any-promise-1.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
     "anymatch": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/anymatch/-/anymatch-3.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/anymatch/-/anymatch-3.1.1.tgz",
       "integrity": "sha1-xV7PAhheJGklk5kxDBc84xIzsUI=",
       "requires": {
         "normalize-path": "^3.0.0",
@@ -1755,17 +1686,17 @@
     },
     "append-field": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/append-field/-/append-field-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/append-field/-/append-field-1.0.0.tgz",
       "integrity": "sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY="
     },
     "aproba": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/aproba/-/aproba-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo="
     },
     "archiver": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/archiver/-/archiver-3.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/archiver/-/archiver-3.1.1.tgz",
       "integrity": "sha1-nbeBnU2vYK7BD+hrFsuSWM7WbqA=",
       "requires": {
         "archiver-utils": "^2.1.0",
@@ -1779,7 +1710,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.6.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
           "requires": {
             "inherits": "^2.0.3",
@@ -1789,12 +1720,12 @@
         },
         "safe-buffer": {
           "version": "5.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY="
         },
         "string_decoder": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.3.0.tgz",
           "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
           "requires": {
             "safe-buffer": "~5.2.0"
@@ -1804,7 +1735,7 @@
     },
     "archiver-utils": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/archiver-utils/-/archiver-utils-2.1.0.tgz",
       "integrity": "sha1-6KRg6UtpPD49oYKgmMpihbqSSeI=",
       "requires": {
         "glob": "^7.1.4",
@@ -1821,7 +1752,7 @@
     },
     "are-we-there-yet": {
       "version": "1.1.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha1-SzXClE8GKov82mZBB2A1D+nd/CE=",
       "requires": {
         "delegates": "^1.0.0",
@@ -1830,7 +1761,7 @@
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/argparse/-/argparse-1.0.10.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "requires": {
         "sprintf-js": "~1.0.2"
@@ -1838,78 +1769,67 @@
     },
     "arr-diff": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arr-diff/-/arr-diff-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/arr-diff/-/arr-diff-4.0.0.tgz",
       "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
     },
     "arr-flatten": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
     },
     "arr-union": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arr-union/-/arr-union-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
     "array-back": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-back/-/array-back-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-back/-/array-back-3.1.0.tgz",
       "integrity": "sha1-uIWdelCIccmnss9C+ZQo9l6Wv7A="
     },
     "array-filter": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-filter/-/array-filter-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-filter/-/array-filter-1.0.0.tgz",
       "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
     },
     "array-find-index": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-find-index/-/array-find-index-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-union": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-union/-/array-union-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha1-t5hCCtvrHego2ErNii4j0+/oXo0="
     },
     "array-uniq": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-uniq/-/array-uniq-1.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
     },
     "array-unique": {
       "version": "0.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-unique/-/array-unique-0.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-    },
-    "array.prototype.map": {
-      "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array.prototype.map/-/array.prototype.map-1.0.2.tgz",
-      "integrity": "sha1-mkFZ9BZFiiPpSDB43hEGsu9o+Ow=",
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1",
-        "es-array-method-boxes-properly": "^1.0.0",
-        "is-string": "^1.0.4"
-      }
     },
     "arraybuffer.slice": {
       "version": "0.0.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
       "integrity": "sha1-O7xCdd1YTMGxCAm4nU6LY6aednU="
     },
     "arrify": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arrify/-/arrify-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "asn1": {
       "version": "0.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/asn1/-/asn1-0.2.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
       "requires": {
         "safer-buffer": "~2.1.0"
@@ -1917,27 +1837,27 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assertion-error": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/assertion-error/-/assertion-error-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs="
     },
     "assign-symbols": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
     "astral-regex": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/astral-regex/-/astral-regex-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha1-bIw/uCfdQ+45GPJ7gngqt2WKb9k="
     },
     "async": {
       "version": "2.6.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-2.6.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/async/-/async-2.6.3.tgz",
       "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
       "requires": {
         "lodash": "^4.17.14"
@@ -1945,27 +1865,27 @@
     },
     "async-exit-hook": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
       "integrity": "sha1-i9iwJLDsmxwBzMua+dspvXF9+vM="
     },
     "async-limiter": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async-limiter/-/async-limiter-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha1-3TeelPDbgxCwgpH51kwyCXZmF/0="
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/atob/-/atob-2.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/atob/-/atob-2.1.2.tgz",
       "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k="
     },
     "available-typed-arrays": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
       "integrity": "sha1-awmMqdgDkHnuP3f3t4PESAulE/U=",
       "requires": {
         "array-filter": "^1.0.0"
@@ -1973,17 +1893,17 @@
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/aws4/-/aws4-1.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/aws4/-/aws4-1.10.1.tgz",
       "integrity": "sha1-4eguTz6Zniz9YbFhKA0WoRH4ZCg="
     },
     "axios": {
       "version": "0.19.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/axios/-/axios-0.19.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/axios/-/axios-0.19.2.tgz",
       "integrity": "sha1-PqNsXYgY0NX4qKl6bTa4bNwAyyc=",
       "requires": {
         "follow-redirects": "1.5.10"
@@ -1991,7 +1911,7 @@
     },
     "babel-code-frame": {
       "version": "6.26.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "requires": {
         "chalk": "^1.1.3",
@@ -2001,12 +1921,12 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -2018,19 +1938,19 @@
         },
         "js-tokens": {
           "version": "3.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/js-tokens/-/js-tokens-3.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/js-tokens/-/js-tokens-3.0.2.tgz",
           "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
     "babel-generator": {
       "version": "6.26.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-generator/-/babel-generator-6.26.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-generator/-/babel-generator-6.26.1.tgz",
       "integrity": "sha1-GERAjTuPDTWkBOp6wYDwh6YBvZA=",
       "requires": {
         "babel-messages": "^6.23.0",
@@ -2045,54 +1965,54 @@
       "dependencies": {
         "jsesc": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsesc/-/jsesc-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/jsesc/-/jsesc-1.3.0.tgz",
           "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
     "babel-helper-evaluate-path": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.5.0.tgz",
       "integrity": "sha1-pi+pxOZP9+pc6pNTF07wI6kApnw="
     },
     "babel-helper-flip-expressions": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.4.3.tgz",
       "integrity": "sha1-NpZzahKKwYvCUlS19AoizrPB0/0="
     },
     "babel-helper-is-nodes-equiv": {
       "version": "0.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
       "integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ="
     },
     "babel-helper-is-void-0": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-is-void-0/-/babel-helper-is-void-0-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-helper-is-void-0/-/babel-helper-is-void-0-0.4.3.tgz",
       "integrity": "sha1-fZwBtFYee5Xb2g9u7kj1tg5nMT4="
     },
     "babel-helper-mark-eval-scopes": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.4.3.tgz",
       "integrity": "sha1-0kSjvvmESHJgP/tG4izorN9VFWI="
     },
     "babel-helper-remove-or-void": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.3.tgz",
       "integrity": "sha1-pPA7QAd6D/6I5F0HAQ3uJB/1rmA="
     },
     "babel-helper-to-multiple-sequence-expressions": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.5.0.tgz",
       "integrity": "sha1-o/kk41YYgtQvz0iQeqmPeXmkWI0="
     },
     "babel-messages": {
       "version": "6.23.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-messages/-/babel-messages-6.23.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "requires": {
         "babel-runtime": "^6.22.0"
@@ -2100,7 +2020,7 @@
     },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
       "integrity": "sha1-hP2hnJduxcbe/vV/lCez3vZuF6M=",
       "requires": {
         "object.assign": "^4.1.0"
@@ -2108,12 +2028,12 @@
     },
     "babel-plugin-minify-builtins": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.5.0.tgz",
       "integrity": "sha1-MeuC7RoNDv3DExL5O25HQc6Cw2s="
     },
     "babel-plugin-minify-constant-folding": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.5.0.tgz",
       "integrity": "sha1-+EvI2/alYeXjUP+VriFrCtVRW24=",
       "requires": {
         "babel-helper-evaluate-path": "^0.5.0"
@@ -2121,7 +2041,7 @@
     },
     "babel-plugin-minify-dead-code-elimination": {
       "version": "0.5.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.5.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.5.1.tgz",
       "integrity": "sha1-Ggxo5EvjDeSXbKaf/FNeCL4TaD8=",
       "requires": {
         "babel-helper-evaluate-path": "^0.5.0",
@@ -2132,7 +2052,7 @@
     },
     "babel-plugin-minify-flip-comparisons": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.4.3.tgz",
       "integrity": "sha1-AMqHDLjxO0XAOLPB68DyJyk8llo=",
       "requires": {
         "babel-helper-is-void-0": "^0.4.3"
@@ -2140,7 +2060,7 @@
     },
     "babel-plugin-minify-guarded-expressions": {
       "version": "0.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.4.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.4.4.tgz",
       "integrity": "sha1-gYlg9kzAiu6dbHW+xtqXTE1iETU=",
       "requires": {
         "babel-helper-evaluate-path": "^0.5.0",
@@ -2149,12 +2069,12 @@
     },
     "babel-plugin-minify-infinity": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.4.3.tgz",
       "integrity": "sha1-37h2obCKBldjhO8/kuZTumB7Oco="
     },
     "babel-plugin-minify-mangle-names": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.5.0.tgz",
       "integrity": "sha1-vN21B8kdLJnhOL1rF6GcPCceP9M=",
       "requires": {
         "babel-helper-mark-eval-scopes": "^0.4.3"
@@ -2162,17 +2082,17 @@
     },
     "babel-plugin-minify-numeric-literals": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.4.3.tgz",
       "integrity": "sha1-jk/VYcefeAEob/YOjF/Z3u6TwLw="
     },
     "babel-plugin-minify-replace": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.5.0.tgz",
       "integrity": "sha1-0+LJlGyQlsBw78lnYc4ojsXD9xw="
     },
     "babel-plugin-minify-simplify": {
       "version": "0.5.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.5.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.5.1.tgz",
       "integrity": "sha1-8hYTyLla80UKLKcVAv29kXk8jWo=",
       "requires": {
         "babel-helper-evaluate-path": "^0.5.0",
@@ -2183,7 +2103,7 @@
     },
     "babel-plugin-minify-type-constructors": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.4.3.tgz",
       "integrity": "sha1-G8bxW4f3qxCF1CszC3F2V6IVZQA=",
       "requires": {
         "babel-helper-is-void-0": "^0.4.3"
@@ -2191,27 +2111,27 @@
     },
     "babel-plugin-transform-inline-consecutive-adds": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.4.3.tgz",
       "integrity": "sha1-Mj1Ho+pjqDp6w8gRro5pQfrysNE="
     },
     "babel-plugin-transform-member-expression-literals": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.4.tgz",
       "integrity": "sha1-NwOcmgwzE6OUlfqsL/OmtbnQOL8="
     },
     "babel-plugin-transform-merge-sibling-variables": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.4.tgz",
       "integrity": "sha1-hbQi/DN3tEnJ0c3kQIcgNTJAHa4="
     },
     "babel-plugin-transform-minify-booleans": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.4.tgz",
       "integrity": "sha1-rLs+VqNVXdI5KOS1gtKFFi3SsZg="
     },
     "babel-plugin-transform-property-literals": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.4.tgz",
       "integrity": "sha1-mMHSHiVXNlc/k+zlRFn2ziSYXTk=",
       "requires": {
         "esutils": "^2.0.2"
@@ -2219,22 +2139,22 @@
     },
     "babel-plugin-transform-regexp-constructors": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.3.tgz",
       "integrity": "sha1-WLd3W2OvzzMyj66aX4j71PsLSWU="
     },
     "babel-plugin-transform-remove-console": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
       "integrity": "sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A="
     },
     "babel-plugin-transform-remove-debugger": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.4.tgz",
       "integrity": "sha1-QrcnYxyXl44estGZp67IShgznvI="
     },
     "babel-plugin-transform-remove-undefined": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.5.0.tgz",
       "integrity": "sha1-gCCLMSJXZsYwyX+i0oiVIFbqIt0=",
       "requires": {
         "babel-helper-evaluate-path": "^0.5.0"
@@ -2242,17 +2162,17 @@
     },
     "babel-plugin-transform-simplify-comparison-operators": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.4.tgz",
       "integrity": "sha1-9ir+CWyrDh9ootdT/fKDiIRxzrk="
     },
     "babel-plugin-transform-undefined-to-void": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz",
       "integrity": "sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA="
     },
     "babel-preset-minify": {
       "version": "0.5.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-preset-minify/-/babel-preset-minify-0.5.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-preset-minify/-/babel-preset-minify-0.5.1.tgz",
       "integrity": "sha1-JfXQvONuyBi+gDONDllBBuIeqp8=",
       "requires": {
         "babel-plugin-minify-builtins": "^0.5.0",
@@ -2282,7 +2202,7 @@
     },
     "babel-runtime": {
       "version": "6.26.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
         "core-js": "^2.4.0",
@@ -2291,14 +2211,14 @@
       "dependencies": {
         "core-js": {
           "version": "2.6.11",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/core-js/-/core-js-2.6.11.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/core-js/-/core-js-2.6.11.tgz",
           "integrity": "sha1-OIMUafmSK97Y7iHJ3EaYXgOZMIw="
         }
       }
     },
     "babel-traverse": {
       "version": "6.26.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "requires": {
         "babel-code-frame": "^6.26.0",
@@ -2314,12 +2234,12 @@
       "dependencies": {
         "babylon": {
           "version": "6.18.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babylon/-/babylon-6.18.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babylon/-/babylon-6.18.0.tgz",
           "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM="
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
@@ -2327,14 +2247,19 @@
         },
         "globals": {
           "version": "9.18.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/globals/-/globals-9.18.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/globals/-/globals-9.18.0.tgz",
           "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
     "babel-types": {
       "version": "6.26.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-types/-/babel-types-6.26.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "requires": {
         "babel-runtime": "^6.26.0",
@@ -2345,29 +2270,29 @@
       "dependencies": {
         "to-fast-properties": {
           "version": "1.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
           "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
         }
       }
     },
     "babylon": {
       "version": "7.0.0-beta.47",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babylon/-/babylon-7.0.0-beta.47.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babylon/-/babylon-7.0.0-beta.47.tgz",
       "integrity": "sha1-bR+kTwq+xBq3x4BIHmL9mq+96oA="
     },
     "backo2": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/backo2/-/backo2-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/backo2/-/backo2-1.0.2.tgz",
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/base/-/base-0.11.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/base/-/base-0.11.2.tgz",
       "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
       "requires": {
         "cache-base": "^1.0.1",
@@ -2381,7 +2306,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
             "is-descriptor": "^1.0.0"
@@ -2389,7 +2314,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "requires": {
             "kind-of": "^6.0.0"
@@ -2397,7 +2322,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "requires": {
             "kind-of": "^6.0.0"
@@ -2405,7 +2330,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -2416,28 +2341,28 @@
       }
     },
     "base64-arraybuffer": {
-      "version": "0.1.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
+      "version": "0.1.4",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
+      "integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI="
     },
     "base64-js": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/base64-js/-/base64-js-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/base64-js/-/base64-js-1.2.0.tgz",
       "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE="
     },
     "base64id": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/base64id/-/base64id-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/base64id/-/base64id-2.0.0.tgz",
       "integrity": "sha1-J3Csa8R9MSr5eov5pjQ0LgzSXLY="
     },
     "basic-auth": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/basic-auth/-/basic-auth-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/basic-auth/-/basic-auth-1.1.0.tgz",
       "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
         "tweetnacl": "^0.14.3"
@@ -2445,7 +2370,7 @@
     },
     "better-assert": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/better-assert/-/better-assert-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/better-assert/-/better-assert-1.0.2.tgz",
       "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
       "requires": {
         "callsite": "1.0.0"
@@ -2453,12 +2378,12 @@
     },
     "binary-extensions": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/binary-extensions/-/binary-extensions-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha1-MPpAyef+B9vIlWeM0ocCTeokHdk="
     },
     "bindings": {
       "version": "1.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bindings/-/bindings-1.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha1-EDU8npRTNLwFEabZCzj7x8nFBN8=",
       "requires": {
         "file-uri-to-path": "1.0.0"
@@ -2466,7 +2391,7 @@
     },
     "bl": {
       "version": "4.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bl/-/bl-4.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/bl/-/bl-4.0.3.tgz",
       "integrity": "sha1-EtYoetwpCA4ipwXldksqlSLNxIk=",
       "requires": {
         "buffer": "^5.5.0",
@@ -2476,7 +2401,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.6.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
           "requires": {
             "inherits": "^2.0.3",
@@ -2486,12 +2411,12 @@
         },
         "safe-buffer": {
           "version": "5.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY="
         },
         "string_decoder": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.3.0.tgz",
           "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
           "requires": {
             "safe-buffer": "~5.2.0"
@@ -2501,12 +2426,12 @@
     },
     "blob": {
       "version": "0.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/blob/-/blob-0.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/blob/-/blob-0.0.5.tgz",
       "integrity": "sha1-1oDu7yX4zZGtUz9bAe7UjmTK9oM="
     },
     "block-stream": {
       "version": "0.0.9",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/block-stream/-/block-stream-0.0.9.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "requires": {
         "inherits": "~2.0.0"
@@ -2514,12 +2439,12 @@
     },
     "bluebird": {
       "version": "3.7.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bluebird/-/bluebird-3.7.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28="
     },
     "body-parser": {
       "version": "1.19.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/body-parser/-/body-parser-1.19.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/body-parser/-/body-parser-1.19.0.tgz",
       "integrity": "sha1-lrJwnlfJxOCab9Zqj9l5hE9p8Io=",
       "requires": {
         "bytes": "3.1.0",
@@ -2536,27 +2461,32 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
           }
         },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
         "qs": {
           "version": "6.7.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/qs/-/qs-6.7.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/qs/-/qs-6.7.0.tgz",
           "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw="
         }
       }
     },
     "bootstrap-sass": {
       "version": "3.3.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bootstrap-sass/-/bootstrap-sass-3.3.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/bootstrap-sass/-/bootstrap-sass-3.3.4.tgz",
       "integrity": "sha1-tis0zRoak1Y6zMTE9daCMXJ3WZY="
     },
     "bower-config": {
       "version": "1.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bower-config/-/bower-config-1.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/bower-config/-/bower-config-1.4.3.tgz",
       "integrity": "sha1-NFT+zcXwjnqpzG1Vbkkr4GaWia4=",
       "requires": {
         "graceful-fs": "^4.1.3",
@@ -2569,19 +2499,19 @@
       "dependencies": {
         "minimist": {
           "version": "0.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimist/-/minimist-0.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minimist/-/minimist-0.2.1.tgz",
           "integrity": "sha1-gnuk51k0ZOfCIejFvtkwkE7ixFU="
         },
         "wordwrap": {
           "version": "0.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wordwrap/-/wordwrap-0.0.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wordwrap/-/wordwrap-0.0.3.tgz",
           "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
         }
       }
     },
     "boxen": {
       "version": "4.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/boxen/-/boxen-4.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/boxen/-/boxen-4.2.0.tgz",
       "integrity": "sha1-5BG2I1fW1tNlh8isPV2XTaoHDmQ=",
       "requires": {
         "ansi-align": "^3.0.0",
@@ -2596,21 +2526,20 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U="
         },
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha1-kK51xCTQCNJiTFvynq0xd+v881k=",
+          "version": "4.3.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
         "chalk": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-3.0.0.tgz",
           "integrity": "sha1-P3PCv1JlkfV0zEksUeJFY0n4ROQ=",
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -2619,7 +2548,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "requires": {
             "color-name": "~1.1.4"
@@ -2627,27 +2556,27 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
         },
         "emoji-regex": {
           "version": "8.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
           "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc="
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0="
         },
         "string-width": {
           "version": "4.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
           "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -2657,7 +2586,7 @@
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
           "requires": {
             "ansi-regex": "^5.0.0"
@@ -2665,7 +2594,7 @@
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "requires": {
             "has-flag": "^4.0.0"
@@ -2675,7 +2604,7 @@
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "requires": {
         "balanced-match": "^1.0.0",
@@ -2684,7 +2613,7 @@
     },
     "braces": {
       "version": "3.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/braces/-/braces-3.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/braces/-/braces-3.0.2.tgz",
       "integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
       "requires": {
         "fill-range": "^7.0.1"
@@ -2692,7 +2621,7 @@
     },
     "browser-capabilities": {
       "version": "1.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/browser-capabilities/-/browser-capabilities-1.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/browser-capabilities/-/browser-capabilities-1.1.4.tgz",
       "integrity": "sha1-pr1legehNFMq1mxyK4lJkER4uXM=",
       "requires": {
         "@types/ua-parser-js": "^0.7.31",
@@ -2701,17 +2630,17 @@
     },
     "browser-process-hrtime": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
       "integrity": "sha1-PJtLfXgsgSHlbxAQbYTA0P/JRiY="
     },
     "browser-stdout": {
       "version": "1.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA="
     },
     "browserstack": {
       "version": "1.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/browserstack/-/browserstack-1.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/browserstack/-/browserstack-1.6.0.tgz",
       "integrity": "sha1-WlarkJh2BdnBONeouIEoNwKX+b8=",
       "optional": true,
       "requires": {
@@ -2720,16 +2649,25 @@
       "dependencies": {
         "agent-base": {
           "version": "4.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/agent-base/-/agent-base-4.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/agent-base/-/agent-base-4.3.0.tgz",
           "integrity": "sha1-gWXwHENgCbzK0LHRIvBe13Dvxu4=",
           "optional": true,
           "requires": {
             "es6-promisify": "^5.0.0"
           }
         },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+          "optional": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
         "es6-promisify": {
           "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/es6-promisify/-/es6-promisify-5.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/es6-promisify/-/es6-promisify-5.0.0.tgz",
           "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
           "optional": true,
           "requires": {
@@ -2738,7 +2676,7 @@
         },
         "https-proxy-agent": {
           "version": "2.2.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
           "integrity": "sha1-TuenN6vZJniik9mzShr00NCMeHs=",
           "optional": true,
           "requires": {
@@ -2748,9 +2686,20 @@
         }
       }
     },
+    "browserstack-local": {
+      "version": "1.4.8",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/browserstack-local/-/browserstack-local-1.4.8.tgz",
+      "integrity": "sha1-B/dKGbMkzy3mn/5l+cK6o6Ldmg4=",
+      "requires": {
+        "https-proxy-agent": "^4.0.0",
+        "is-running": "^2.1.0",
+        "ps-tree": "=1.2.0",
+        "temp-fs": "^0.9.9"
+      }
+    },
     "buffer": {
       "version": "5.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/buffer/-/buffer-5.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/buffer/-/buffer-5.6.0.tgz",
       "integrity": "sha1-oxdJ3H2B2E2wir+Te2uMQDP2J4Y=",
       "requires": {
         "base64-js": "^1.0.2",
@@ -2759,17 +2708,17 @@
     },
     "buffer-crc32": {
       "version": "0.2.13",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
     "buffer-from": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/buffer-from/-/buffer-from-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8="
     },
     "bufferstreams": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bufferstreams/-/bufferstreams-1.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/bufferstreams/-/bufferstreams-1.1.3.tgz",
       "integrity": "sha1-qFFawCT6kOj6fVjBGxPeofKKvnI=",
       "requires": {
         "readable-stream": "^2.0.2"
@@ -2777,12 +2726,12 @@
     },
     "builtins": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/builtins/-/builtins-1.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/builtins/-/builtins-1.0.3.tgz",
       "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
     },
     "busboy": {
       "version": "0.2.14",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/busboy/-/busboy-0.2.14.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/busboy/-/busboy-0.2.14.tgz",
       "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
       "requires": {
         "dicer": "0.2.5",
@@ -2791,7 +2740,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -2804,12 +2753,12 @@
     },
     "bytes": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bytes/-/bytes-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha1-9s95M6Ng4FiPqf3oVlHNx/gF0fY="
     },
     "cache-base": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cache-base/-/cache-base-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
       "requires": {
         "collection-visit": "^1.0.0",
@@ -2825,7 +2774,7 @@
     },
     "cacheable-lookup": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cacheable-lookup/-/cacheable-lookup-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cacheable-lookup/-/cacheable-lookup-2.0.1.tgz",
       "integrity": "sha1-h75koYuSUjSHXhCpux68pK3Oazg=",
       "requires": {
         "@types/keyv": "^3.1.1",
@@ -2834,7 +2783,7 @@
     },
     "cacheable-request": {
       "version": "7.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cacheable-request/-/cacheable-request-7.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cacheable-request/-/cacheable-request-7.0.1.tgz",
       "integrity": "sha1-BiAxwoViMngu1pSiV/o12pOUKlg=",
       "requires": {
         "clone-response": "^1.0.2",
@@ -2848,24 +2797,24 @@
       "dependencies": {
         "lowercase-keys": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
           "integrity": "sha1-JgPni3tLAAbLyi+8yKMgJVislHk="
         }
       }
     },
     "callsite": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/callsite/-/callsite-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/callsite/-/callsite-1.0.0.tgz",
       "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
     },
     "callsites": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/callsites/-/callsites-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M="
     },
     "camel-case": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camel-case/-/camel-case-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "requires": {
         "no-case": "^2.2.0",
@@ -2874,12 +2823,12 @@
     },
     "camelcase": {
       "version": "5.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase/-/camelcase-5.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA="
     },
     "camelcase-keys": {
       "version": "6.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
       "integrity": "sha1-XnVda6UaoiPsfT1S8ld4IQ+dw8A=",
       "requires": {
         "camelcase": "^5.3.1",
@@ -2889,32 +2838,32 @@
     },
     "cancel-token": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cancel-token/-/cancel-token-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cancel-token/-/cancel-token-0.1.1.tgz",
       "integrity": "sha1-wYGXZ0uxyEwdaTPr8V2NWlznm08=",
       "requires": {
         "@types/node": "^4.0.30"
       },
       "dependencies": {
         "@types/node": {
-          "version": "4.9.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/node/-/node-4.9.4.tgz",
-          "integrity": "sha1-de+Rczr6qFawHhLabs9Iqp1eIh8="
+          "version": "4.9.5",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/node/-/node-4.9.5.tgz",
+          "integrity": "sha1-o3hduWsHpLVkZsyZ/WJIOHRvLiU="
         }
       }
     },
     "capture-stack-trace": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
       "integrity": "sha1-psC74fOPOqC5Ijjstv9Cw0TUE10="
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chai": {
       "version": "4.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chai/-/chai-4.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chai/-/chai-4.2.0.tgz",
       "integrity": "sha1-dgqnLPION5XoSxKHfODoNzeqKeU=",
       "requires": {
         "assertion-error": "^1.1.0",
@@ -2927,7 +2876,7 @@
     },
     "chai-as-promised": {
       "version": "7.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
       "integrity": "sha1-CGRdgl3rhpbuYXJdv1kMAS6wDKA=",
       "requires": {
         "check-error": "^1.0.2"
@@ -2935,7 +2884,7 @@
     },
     "chalk": {
       "version": "4.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-4.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-4.1.0.tgz",
       "integrity": "sha1-ThSHCmGNni7dl92DRf2dncMVZGo=",
       "requires": {
         "ansi-styles": "^4.1.0",
@@ -2943,17 +2892,16 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha1-kK51xCTQCNJiTFvynq0xd+v881k=",
+          "version": "4.3.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "requires": {
             "color-name": "~1.1.4"
@@ -2961,17 +2909,17 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "requires": {
             "has-flag": "^4.0.0"
@@ -2981,22 +2929,22 @@
     },
     "chardet": {
       "version": "0.7.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chardet/-/chardet-0.7.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha1-kAlISfCTfy7twkJdDSip5fDLrZ4="
     },
     "charenc": {
       "version": "0.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/charenc/-/charenc-0.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/charenc/-/charenc-0.0.2.tgz",
       "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
     },
     "check-error": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/check-error/-/check-error-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
     },
     "choices.js": {
       "version": "3.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/choices.js/-/choices.js-3.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/choices.js/-/choices.js-3.0.3.tgz",
       "integrity": "sha1-KKoOljKMIq4HS+X+bp7aU4TlS0U=",
       "requires": {
         "classnames": "^2.2.5",
@@ -3006,9 +2954,9 @@
       }
     },
     "chokidar": {
-      "version": "3.4.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chokidar/-/chokidar-3.4.2.tgz",
-      "integrity": "sha1-ONyOZY3sOAl0HrPve7Ckf+QkIy0=",
+      "version": "3.4.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chokidar/-/chokidar-3.4.3.tgz",
+      "integrity": "sha1-wd84IxRI5FykrFiObHlXO6alfVs=",
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
@@ -3017,18 +2965,18 @@
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.4.0"
+        "readdirp": "~3.5.0"
       }
     },
     "chownr": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chownr/-/chownr-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha1-Fb++U9LqtM9w8YqM1o6+Wzyx3s4="
     },
     "chromedriver": {
-      "version": "84.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chromedriver/-/chromedriver-84.0.1.tgz",
-      "integrity": "sha1-6sp3I/GljCYqXFIbhZZ2mvQLDU8=",
+      "version": "85.0.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chromedriver/-/chromedriver-85.0.1.tgz",
+      "integrity": "sha1-LhtXGEUlM2j80RIQjyPrnHePeYI=",
       "requires": {
         "@testim/chrome-version": "^1.0.7",
         "axios": "^0.19.2",
@@ -3039,21 +2987,38 @@
         "tcp-port-used": "^1.0.1"
       },
       "dependencies": {
+        "agent-base": {
+          "version": "6.0.1",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/agent-base/-/agent-base-6.0.1.tgz",
+          "integrity": "sha1-gIAH5OWGfeywq2qy+Sj721pZbbQ=",
+          "requires": {
+            "debug": "4"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha1-4qkFQqu2inYuCghQ9sntrf2FBrI=",
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
         "mkdirp": {
           "version": "1.0.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mkdirp/-/mkdirp-1.0.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34="
         }
       }
     },
     "ci-info": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ci-info/-/ci-info-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha1-Z6npZL4xpR4V5QENWObxKDQAL0Y="
     },
     "class-utils": {
       "version": "0.3.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/class-utils/-/class-utils-0.3.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
       "requires": {
         "arr-union": "^3.1.0",
@@ -3064,7 +3029,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -3074,17 +3039,17 @@
     },
     "classlist-polyfill": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
       "integrity": "sha1-k1vC39lFiodrJ5YXUUY4vKqWSi4="
     },
     "classnames": {
       "version": "2.2.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/classnames/-/classnames-2.2.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/classnames/-/classnames-2.2.6.tgz",
       "integrity": "sha1-Q5Nb/90pHzJtrQogUwmzjQD2UM4="
     },
     "clean-css": {
       "version": "4.2.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clean-css/-/clean-css-4.2.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/clean-css/-/clean-css-4.2.3.tgz",
       "integrity": "sha1-UHtd59l7SO5T2ErbAWD/YhY4D3g=",
       "requires": {
         "source-map": "~0.6.0"
@@ -3092,27 +3057,27 @@
     },
     "clean-stack": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clean-stack/-/clean-stack-2.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha1-7oRy27Ep5yezHooQpCfe6d/kAIs="
     },
     "cleankill": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cleankill/-/cleankill-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cleankill/-/cleankill-2.0.0.tgz",
       "integrity": "sha1-WYMN/ItBHVPccq0J1Fp46jMWGpE="
     },
     "cleave.js": {
       "version": "1.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cleave.js/-/cleave.js-1.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cleave.js/-/cleave.js-1.6.0.tgz",
       "integrity": "sha1-Dk4BGUO91wxnydz0/4AM5xBSkXE="
     },
     "cli-boxes": {
       "version": "2.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cli-boxes/-/cli-boxes-2.2.1.tgz",
       "integrity": "sha1-3dUDXSUJT84iDpyrQKRYQKRAMY8="
     },
     "cli-cursor": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha1-JkMFp65JDR0Dvwybp8kl0XU68wc=",
       "requires": {
         "restore-cursor": "^3.1.0"
@@ -3120,7 +3085,7 @@
     },
     "cli-truncate": {
       "version": "0.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cli-truncate/-/cli-truncate-0.2.1.tgz",
       "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
       "requires": {
         "slice-ansi": "0.0.4",
@@ -3129,19 +3094,19 @@
       "dependencies": {
         "slice-ansi": {
           "version": "0.0.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/slice-ansi/-/slice-ansi-0.0.4.tgz",
           "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
         }
       }
     },
     "cli-width": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-width/-/cli-width-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cli-width/-/cli-width-3.0.0.tgz",
       "integrity": "sha1-ovSEN6LKqaIkNueUvwceyeYc7fY="
     },
     "clipboard": {
       "version": "2.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clipboard/-/clipboard-2.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/clipboard/-/clipboard-2.0.6.tgz",
       "integrity": "sha1-UpISlu7A/fd+rRdJQhshyWhkc3Y=",
       "requires": {
         "good-listener": "^1.2.2",
@@ -3151,7 +3116,7 @@
     },
     "cliui": {
       "version": "5.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cliui/-/cliui-5.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
       "requires": {
         "string-width": "^3.1.0",
@@ -3161,17 +3126,17 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "requires": {
             "emoji-regex": "^7.0.1",
@@ -3181,7 +3146,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -3191,12 +3156,12 @@
     },
     "clone": {
       "version": "2.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clone/-/clone-2.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/clone/-/clone-2.1.2.tgz",
       "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "clone-response": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clone-response/-/clone-response-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/clone-response/-/clone-response-1.0.2.tgz",
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "requires": {
         "mimic-response": "^1.0.0"
@@ -3204,24 +3169,24 @@
       "dependencies": {
         "mimic-response": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mimic-response/-/mimic-response-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mimic-response/-/mimic-response-1.0.1.tgz",
           "integrity": "sha1-SSNTiHju9CBjy4o+OweYeBSHqxs="
         }
       }
     },
     "clone-stats": {
       "version": "0.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clone-stats/-/clone-stats-0.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/clone-stats/-/clone-stats-0.0.1.tgz",
       "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
     },
     "code-point-at": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/code-point-at/-/code-point-at-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "collection-visit": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/collection-visit/-/collection-visit-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "requires": {
         "map-visit": "^1.0.0",
@@ -3230,7 +3195,7 @@
     },
     "color": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color/-/color-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color/-/color-3.0.0.tgz",
       "integrity": "sha1-2SC0Mo1TSjrIKV1o971LpsQnvpo=",
       "requires": {
         "color-convert": "^1.9.1",
@@ -3239,7 +3204,7 @@
     },
     "color-convert": {
       "version": "1.9.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-convert/-/color-convert-1.9.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
       "requires": {
         "color-name": "1.1.3"
@@ -3247,13 +3212,13 @@
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
-      "version": "1.5.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-string/-/color-string-1.5.3.tgz",
-      "integrity": "sha1-ybvF8BtYtUkvPWhXRZy2WQziBMw=",
+      "version": "1.5.4",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-string/-/color-string-1.5.4.tgz",
+      "integrity": "sha1-3VHNJc/ulT0Tj+QAI3LMPQ5QTLY=",
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -3261,12 +3226,12 @@
     },
     "colors": {
       "version": "1.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/colors/-/colors-1.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/colors/-/colors-1.4.0.tgz",
       "integrity": "sha1-xQSRR51MG9rtLJztMs98fcI2D3g="
     },
     "colorspace": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/colorspace/-/colorspace-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/colorspace/-/colorspace-1.1.2.tgz",
       "integrity": "sha1-4BKJUNCCuGohaFgHlqCqXWxo2MU=",
       "requires": {
         "color": "3.0.x",
@@ -3275,7 +3240,7 @@
     },
     "combined-stream": {
       "version": "1.0.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
       "requires": {
         "delayed-stream": "~1.0.0"
@@ -3283,7 +3248,7 @@
     },
     "command-line-args": {
       "version": "5.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/command-line-args/-/command-line-args-5.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/command-line-args/-/command-line-args-5.1.1.tgz",
       "integrity": "sha1-iOeT5bs86zB1SoaGPwQBrJL9Npo=",
       "requires": {
         "array-back": "^3.0.1",
@@ -3294,7 +3259,7 @@
     },
     "command-line-usage": {
       "version": "5.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/command-line-usage/-/command-line-usage-5.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/command-line-usage/-/command-line-usage-5.0.5.tgz",
       "integrity": "sha1-XyWTP/5t7dmDxjXTiiHX5iP9o1c=",
       "requires": {
         "array-back": "^2.0.0",
@@ -3305,7 +3270,7 @@
       "dependencies": {
         "array-back": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-back/-/array-back-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-back/-/array-back-2.0.0.tgz",
           "integrity": "sha1-aHdHHVHsycm/phNvtsfV/ml0gCI=",
           "requires": {
             "typical": "^2.6.1"
@@ -3313,7 +3278,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -3323,34 +3288,34 @@
         },
         "typical": {
           "version": "2.6.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typical/-/typical-2.6.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/typical/-/typical-2.6.1.tgz",
           "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
         }
       }
     },
     "commander": {
       "version": "2.20.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/commander/-/commander-2.20.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/commander/-/commander-2.20.3.tgz",
       "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM="
     },
     "component-bind": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-bind/-/component-bind-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/component-bind/-/component-bind-1.0.0.tgz",
       "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
     },
     "component-emitter": {
       "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A="
     },
     "component-inherit": {
       "version": "0.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-inherit/-/component-inherit-0.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/component-inherit/-/component-inherit-0.0.3.tgz",
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
     },
     "compress-commons": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/compress-commons/-/compress-commons-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/compress-commons/-/compress-commons-2.1.1.tgz",
       "integrity": "sha1-lBDZpTTPhDXj+7t8bOSN4twvBhA=",
       "requires": {
         "buffer-crc32": "^0.2.13",
@@ -3361,7 +3326,7 @@
     },
     "compressible": {
       "version": "2.0.18",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/compressible/-/compressible-2.0.18.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/compressible/-/compressible-2.0.18.tgz",
       "integrity": "sha1-r1PMprBw1MPAdQ+9dyhqbXzEb7o=",
       "requires": {
         "mime-db": ">= 1.43.0 < 2"
@@ -3369,7 +3334,7 @@
     },
     "compression": {
       "version": "1.7.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/compression/-/compression-1.7.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/compression/-/compression-1.7.4.tgz",
       "integrity": "sha1-lVI+/xcMpXwpoMpB5v4TH0Hlu48=",
       "requires": {
         "accepts": "~1.3.5",
@@ -3383,27 +3348,32 @@
       "dependencies": {
         "bytes": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bytes/-/bytes-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/bytes/-/bytes-3.0.0.tgz",
           "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/concat-stream/-/concat-stream-1.6.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
       "requires": {
         "buffer-from": "^1.0.0",
@@ -3414,7 +3384,7 @@
     },
     "configstore": {
       "version": "5.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/configstore/-/configstore-5.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/configstore/-/configstore-5.0.1.tgz",
       "integrity": "sha1-02UCG130uYzdGH1qOw4/anzF7ZY=",
       "requires": {
         "dot-prop": "^5.2.0",
@@ -3427,12 +3397,12 @@
     },
     "console-control-strings": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "content-disposition": {
       "version": "0.5.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/content-disposition/-/content-disposition-0.5.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/content-disposition/-/content-disposition-0.5.3.tgz",
       "integrity": "sha1-4TDK9+cnkIfFYWwgB9BIVpiYT70=",
       "requires": {
         "safe-buffer": "5.1.2"
@@ -3440,12 +3410,12 @@
     },
     "content-type": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/content-type/-/content-type-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js="
     },
     "convert-source-map": {
       "version": "1.7.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/convert-source-map/-/convert-source-map-1.7.0.tgz",
       "integrity": "sha1-F6LLiC1/d9NJBYXizmxSRCSjpEI=",
       "requires": {
         "safe-buffer": "~5.1.1"
@@ -3453,17 +3423,17 @@
     },
     "cookie": {
       "version": "0.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cookie/-/cookie-0.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cookie/-/cookie-0.4.0.tgz",
       "integrity": "sha1-vrQ35wIrO21JAZ0IhmUwPr6cFLo="
     },
     "cookie-signature": {
       "version": "1.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "copy-descriptor": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "copyfiles": {
@@ -3481,33 +3451,183 @@
         "yargs": "^15.3.1"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha1-UR1wLAxOQcoVbX0OlgIfI+EyJbE=",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+          "dev": true
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
         "mkdirp": {
           "version": "1.0.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mkdirp/-/mkdirp-1.0.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
           "dev": true
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
         },
         "untildify": {
           "version": "4.0.0",
           "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/untildify/-/untildify-4.0.0.tgz",
           "integrity": "sha1-K8lHuVNlJIfkYAlJ+wkeOujNkZs=",
           "dev": true
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha1-6Tk7oHEC5skaOyIUePAlfNKFblM=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha1-DYehbeAa7p2L7Cv7909nhRcw9Pg=",
+          "dev": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha1-vmjEl1xrKr9GkjawyHA2L6sJp7A=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
         }
       }
     },
     "core-js": {
       "version": "3.6.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/core-js/-/core-js-3.6.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/core-js/-/core-js-3.6.5.tgz",
       "integrity": "sha1-c5XcJzrzf7LlDpvT2f6EEoUjHRo="
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cors": {
       "version": "2.8.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cors/-/cors-2.8.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cors/-/cors-2.8.5.tgz",
       "integrity": "sha1-6sEdpRWS3Ya58G9uesKTs9+HXSk=",
       "requires": {
         "object-assign": "^4",
@@ -3516,12 +3636,12 @@
     },
     "corser": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/corser/-/corser-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/corser/-/corser-2.0.1.tgz",
       "integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c="
     },
     "cosmiconfig": {
       "version": "6.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
       "integrity": "sha1-2k/uhTxS9rHmk19BwaL8UL1KmYI=",
       "requires": {
         "@types/parse-json": "^4.0.0",
@@ -3533,7 +3653,7 @@
       "dependencies": {
         "parse-json": {
           "version": "5.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse-json/-/parse-json-5.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse-json/-/parse-json-5.1.0.tgz",
           "integrity": "sha1-+WCIzfJKj6qa6poAny2dlCyZlkY=",
           "requires": {
             "@babel/code-frame": "^7.0.0",
@@ -3546,7 +3666,7 @@
     },
     "crc": {
       "version": "3.8.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/crc/-/crc-3.8.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/crc/-/crc-3.8.0.tgz",
       "integrity": "sha1-rWAmnCyFb4wpnixMwN5FVpFAVsY=",
       "requires": {
         "buffer": "^5.1.0"
@@ -3554,7 +3674,7 @@
     },
     "crc32-stream": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/crc32-stream/-/crc32-stream-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/crc32-stream/-/crc32-stream-3.0.1.tgz",
       "integrity": "sha1-yubu7QA7DkTXOdJ53lrmOxcbToU=",
       "requires": {
         "crc": "^3.4.4",
@@ -3563,7 +3683,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.6.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
           "requires": {
             "inherits": "^2.0.3",
@@ -3573,12 +3693,12 @@
         },
         "safe-buffer": {
           "version": "5.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY="
         },
         "string_decoder": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.3.0.tgz",
           "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
           "requires": {
             "safe-buffer": "~5.2.0"
@@ -3588,7 +3708,7 @@
     },
     "create-error-class": {
       "version": "3.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/create-error-class/-/create-error-class-3.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "requires": {
         "capture-stack-trace": "^1.0.0"
@@ -3596,7 +3716,7 @@
     },
     "cross-spawn": {
       "version": "7.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha1-9zqFudXUHQRVUcF34ogtSshXKKY=",
       "requires": {
         "path-key": "^3.1.0",
@@ -3606,7 +3726,7 @@
       "dependencies": {
         "which": {
           "version": "2.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/which/-/which-2.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/which/-/which-2.0.2.tgz",
           "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
           "requires": {
             "isexe": "^2.0.0"
@@ -3616,22 +3736,22 @@
     },
     "crypt": {
       "version": "0.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/crypt/-/crypt-0.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "crypto-random-string": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
       "integrity": "sha1-7yp6lm7BEIM4g2m6oC6+rSKbMNU="
     },
     "css-b64-images": {
       "version": "0.2.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/css-b64-images/-/css-b64-images-0.2.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/css-b64-images/-/css-b64-images-0.2.5.tgz",
       "integrity": "sha1-QgBdgyBLK0pdk7axpWRBM7WSegI="
     },
     "css-slam": {
       "version": "2.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/css-slam/-/css-slam-2.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/css-slam/-/css-slam-2.1.2.tgz",
       "integrity": "sha1-PTWxkiyz4AAqRciasYlJJQjEk+U=",
       "requires": {
         "command-line-args": "^5.0.2",
@@ -3643,29 +3763,29 @@
       "dependencies": {
         "parse5": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse5/-/parse5-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse5/-/parse5-4.0.0.tgz",
           "integrity": "sha1-bXhlbj2o14tOwLkG98CO8d/j9gg="
         }
       }
     },
     "css-vars-ponyfill": {
       "version": "1.17.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/css-vars-ponyfill/-/css-vars-ponyfill-1.17.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/css-vars-ponyfill/-/css-vars-ponyfill-1.17.2.tgz",
       "integrity": "sha1-GOx7wv0Ybr+vme42eyYortQ4ids="
     },
     "cssbeautify": {
       "version": "0.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cssbeautify/-/cssbeautify-0.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cssbeautify/-/cssbeautify-0.3.1.tgz",
       "integrity": "sha1-Et0fc0A1wub6ymfcvc73TkKBE5c="
     },
     "cssom": {
       "version": "0.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cssom/-/cssom-0.4.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cssom/-/cssom-0.4.4.tgz",
       "integrity": "sha1-WmbPk9LQtmHYC/akT7ZfXC5OChA="
     },
     "cssstyle": {
       "version": "2.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cssstyle/-/cssstyle-2.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cssstyle/-/cssstyle-2.3.0.tgz",
       "integrity": "sha1-/2ZaDdvcMYZLCWR/NBY0Q9kLCFI=",
       "requires": {
         "cssom": "~0.3.6"
@@ -3673,19 +3793,19 @@
       "dependencies": {
         "cssom": {
           "version": "0.3.8",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cssom/-/cssom-0.3.8.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cssom/-/cssom-0.3.8.tgz",
           "integrity": "sha1-nxJ29bK0Y/IRTT8sdSUK+MGjb0o="
         }
       }
     },
     "cubic2quad": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cubic2quad/-/cubic2quad-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cubic2quad/-/cubic2quad-1.1.1.tgz",
       "integrity": "sha1-abGcYaP1tB7PLx1fro+wNBWqixU="
     },
     "currently-unhandled": {
       "version": "0.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "requires": {
         "array-find-index": "^1.0.1"
@@ -3693,7 +3813,7 @@
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -3701,7 +3821,7 @@
     },
     "data-urls": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/data-urls/-/data-urls-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/data-urls/-/data-urls-2.0.0.tgz",
       "integrity": "sha1-FWSFpyljqXD11YIar2Qr7yvy25s=",
       "requires": {
         "abab": "^2.0.3",
@@ -3711,7 +3831,7 @@
       "dependencies": {
         "tr46": {
           "version": "2.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tr46/-/tr46-2.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tr46/-/tr46-2.0.2.tgz",
           "integrity": "sha1-Ayc1ht7xWVrgj+2zjXczzukdJHk=",
           "requires": {
             "punycode": "^2.1.1"
@@ -3719,13 +3839,13 @@
         },
         "webidl-conversions": {
           "version": "6.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
           "integrity": "sha1-kRG01+qArNQPUnDWZmIa+ni2lRQ="
         },
         "whatwg-url": {
-          "version": "8.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/whatwg-url/-/whatwg-url-8.2.2.tgz",
-          "integrity": "sha1-hef5eVEItT1VTOxkCy6K7ioNS/0=",
+          "version": "8.4.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/whatwg-url/-/whatwg-url-8.4.0.tgz",
+          "integrity": "sha1-UPuWFbBUaVkdKyvW367SlC7XKDc=",
           "requires": {
             "lodash.sortby": "^4.7.0",
             "tr46": "^2.0.2",
@@ -3736,25 +3856,25 @@
     },
     "date-fns": {
       "version": "1.30.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/date-fns/-/date-fns-1.30.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/date-fns/-/date-fns-1.30.1.tgz",
       "integrity": "sha1-LnG/CxGRU9u0zE6I2epaz7UNwFw="
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+      "version": "4.2.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.2.0.tgz",
+      "integrity": "sha1-fxUPk5IOlMWPVXTC/QGjEQ7/5/E=",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "2.1.2"
       }
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decamelize-keys": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "requires": {
         "decamelize": "^1.1.0",
@@ -3763,24 +3883,24 @@
       "dependencies": {
         "map-obj": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-obj/-/map-obj-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/map-obj/-/map-obj-1.0.1.tgz",
           "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
         }
       }
     },
     "decimal.js": {
-      "version": "10.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/decimal.js/-/decimal.js-10.2.0.tgz",
-      "integrity": "sha1-OUZhE6ngNhEdAvgkibX9awte0jE="
+      "version": "10.2.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/decimal.js/-/decimal.js-10.2.1.tgz",
+      "integrity": "sha1-I4rnsPDHk9PjzqQQEIs1osAUJqM="
     },
     "decode-uri-component": {
       "version": "0.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "decompress-response": {
       "version": "5.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/decompress-response/-/decompress-response-5.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/decompress-response/-/decompress-response-5.0.0.tgz",
       "integrity": "sha1-eEk5boDj0euoyy9170kw92Rhyw8=",
       "requires": {
         "mimic-response": "^2.0.0"
@@ -3788,7 +3908,7 @@
     },
     "deep-eql": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/deep-eql/-/deep-eql-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/deep-eql/-/deep-eql-3.0.1.tgz",
       "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
       "requires": {
         "type-detect": "^4.0.0"
@@ -3796,27 +3916,27 @@
     },
     "deep-extend": {
       "version": "0.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/deep-extend/-/deep-extend-0.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw="
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "deepmerge": {
       "version": "2.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/deepmerge/-/deepmerge-2.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/deepmerge/-/deepmerge-2.2.1.tgz",
       "integrity": "sha1-XT/yKgHAD2RUBaL7wX0HeKGAEXA="
     },
     "defer-to-connect": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
       "integrity": "sha1-g9axmdsEFZOshNeBtSIjCMz0wsE="
     },
     "define-properties": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-properties/-/define-properties-1.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
       "requires": {
         "object-keys": "^1.0.12"
@@ -3824,7 +3944,7 @@
     },
     "define-property": {
       "version": "2.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-2.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
       "requires": {
         "is-descriptor": "^1.0.2",
@@ -3833,7 +3953,7 @@
       "dependencies": {
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "requires": {
             "kind-of": "^6.0.0"
@@ -3841,7 +3961,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "requires": {
             "kind-of": "^6.0.0"
@@ -3849,7 +3969,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -3861,7 +3981,7 @@
     },
     "del": {
       "version": "5.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/del/-/del-5.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/del/-/del-5.1.0.tgz",
       "integrity": "sha1-2Uh8lONnQQ5u/ykl7ljAyEp1s6c=",
       "requires": {
         "globby": "^10.0.1",
@@ -3876,7 +3996,7 @@
       "dependencies": {
         "rimraf": {
           "version": "3.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rimraf/-/rimraf-3.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/rimraf/-/rimraf-3.0.2.tgz",
           "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
           "requires": {
             "glob": "^7.1.3"
@@ -3886,37 +4006,37 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegate": {
       "version": "3.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/delegate/-/delegate-3.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/delegate/-/delegate-3.2.0.tgz",
       "integrity": "sha1-tmtxwxWFIuirV0T3INjKDCr1kWY="
     },
     "delegates": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/delegates/-/delegates-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "depd": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/depd/-/depd-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "destroy": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/destroy/-/destroy-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "detect-file": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/detect-file/-/detect-file-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
     },
     "detect-indent": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/detect-indent/-/detect-indent-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "requires": {
         "repeating": "^2.0.0"
@@ -3924,12 +4044,12 @@
     },
     "detect-node": {
       "version": "2.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/detect-node/-/detect-node-2.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/detect-node/-/detect-node-2.0.4.tgz",
       "integrity": "sha1-AU7o+PZpxcWAI9pkuBecCDooxGw="
     },
     "dicer": {
       "version": "0.2.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dicer/-/dicer-0.2.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/dicer/-/dicer-0.2.5.tgz",
       "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
       "requires": {
         "readable-stream": "1.1.x",
@@ -3938,7 +4058,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -3951,12 +4071,12 @@
     },
     "diff": {
       "version": "4.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/diff/-/diff-4.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/diff/-/diff-4.0.2.tgz",
       "integrity": "sha1-YPOuy4nV+uUgwRqhnvwruYKq3n0="
     },
     "dir-glob": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dir-glob/-/dir-glob-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha1-Vtv3PZkqSpO6FYT0U0Bj/S5BcX8=",
       "requires": {
         "path-type": "^4.0.0"
@@ -3964,23 +4084,15 @@
     },
     "doctrine": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/doctrine/-/doctrine-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha1-rd6+rXKmV023g2OdyHoSF3OXOWE=",
       "requires": {
         "esutils": "^2.0.2"
       }
     },
-    "document-register-element": {
-      "version": "1.14.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/document-register-element/-/document-register-element-1.14.6.tgz",
-      "integrity": "sha1-OGZSg9dXtGO6tUl6c2JM9nDeqyo=",
-      "requires": {
-        "lightercollective": "^0.3.0"
-      }
-    },
     "dom-serializer": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dom-serializer/-/dom-serializer-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/dom-serializer/-/dom-serializer-1.1.0.tgz",
       "integrity": "sha1-X3yCjxv8RIh9wqMVq1xFaR1US1g=",
       "requires": {
         "domelementtype": "^2.0.1",
@@ -3990,7 +4102,7 @@
     },
     "dom-urls": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dom-urls/-/dom-urls-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/dom-urls/-/dom-urls-1.1.0.tgz",
       "integrity": "sha1-AB3fgWKM0ecGElxxdvU8zsVdkY4=",
       "requires": {
         "urijs": "^1.16.1"
@@ -3998,7 +4110,7 @@
     },
     "dom5": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dom5/-/dom5-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/dom5/-/dom5-3.0.1.tgz",
       "integrity": "sha1-zfxzMfN24oS/N55uoFSvwTZwKUQ=",
       "requires": {
         "@types/parse5": "^2.2.34",
@@ -4008,19 +4120,19 @@
       "dependencies": {
         "parse5": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse5/-/parse5-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse5/-/parse5-4.0.0.tgz",
           "integrity": "sha1-bXhlbj2o14tOwLkG98CO8d/j9gg="
         }
       }
     },
     "domelementtype": {
       "version": "2.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/domelementtype/-/domelementtype-2.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/domelementtype/-/domelementtype-2.0.2.tgz",
       "integrity": "sha1-87blSSAeRvWItZRj3XcYcTH+aXE="
     },
     "domexception": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/domexception/-/domexception-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/domexception/-/domexception-2.0.1.tgz",
       "integrity": "sha1-+0Su+6eT4VdLCvau0oAdBXUp8wQ=",
       "requires": {
         "webidl-conversions": "^5.0.0"
@@ -4028,32 +4140,32 @@
       "dependencies": {
         "webidl-conversions": {
           "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
           "integrity": "sha1-rlnIoAsSFUOirMZcBDT1ew/BGv8="
         }
       }
     },
     "domhandler": {
-      "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/domhandler/-/domhandler-3.0.0.tgz",
-      "integrity": "sha1-Uc0T78ox2pW7sMW+46SDAOMzs+k=",
+      "version": "3.3.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/domhandler/-/domhandler-3.3.0.tgz",
+      "integrity": "sha1-bbfqRuRhfrFc+HXfaLK4UkzgA3o=",
       "requires": {
         "domelementtype": "^2.0.1"
       }
     },
     "domutils": {
-      "version": "2.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/domutils/-/domutils-2.3.0.tgz",
-      "integrity": "sha1-ZGnGOj2i3gwwFvOlnmqWnhBwW84=",
+      "version": "2.4.2",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/domutils/-/domutils-2.4.2.tgz",
+      "integrity": "sha1-fuW+JhlE4a1IfZqgYWcgAQEjkis=",
       "requires": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.0.1",
-        "domhandler": "^3.0.0"
+        "domhandler": "^3.3.0"
       }
     },
     "dot-prop": {
       "version": "5.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dot-prop/-/dot-prop-5.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/dot-prop/-/dot-prop-5.3.0.tgz",
       "integrity": "sha1-kMzOcIzZzYLMTcjD3dmr3VWyDog=",
       "requires": {
         "is-obj": "^2.0.0"
@@ -4061,12 +4173,12 @@
     },
     "duplexer": {
       "version": "0.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/duplexer/-/duplexer-0.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha1-Or5DrvODX4rgd9E23c4PJ2sEAOY="
     },
     "duplexer2": {
       "version": "0.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/duplexer2/-/duplexer2-0.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/duplexer2/-/duplexer2-0.1.4.tgz",
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "requires": {
         "readable-stream": "^2.0.2"
@@ -4074,12 +4186,12 @@
     },
     "duplexer3": {
       "version": "0.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/duplexer3/-/duplexer3-0.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "duplexify": {
       "version": "3.7.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/duplexify/-/duplexify-3.7.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha1-Kk31MX9sz9kfhtb9JdjYoQO4gwk=",
       "requires": {
         "end-of-stream": "^1.0.0",
@@ -4090,7 +4202,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "requires": {
         "jsbn": "~0.1.0",
@@ -4099,7 +4211,7 @@
     },
     "ecstatic": {
       "version": "3.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ecstatic/-/ecstatic-3.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ecstatic/-/ecstatic-3.3.2.tgz",
       "integrity": "sha1-bR3UmBTQBZRoLGUq22YHamnUbEg=",
       "requires": {
         "he": "^1.1.1",
@@ -4110,44 +4222,44 @@
       "dependencies": {
         "url-join": {
           "version": "2.0.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/url-join/-/url-join-2.0.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/url-join/-/url-join-2.0.5.tgz",
           "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg="
         }
       }
     },
     "ee-first": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ee-first/-/ee-first-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "elegant-spinner": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4="
     },
     "emitter-component": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/emitter-component/-/emitter-component-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emitter-component/-/emitter-component-1.1.1.tgz",
       "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY="
     },
     "emoji-regex": {
       "version": "7.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY="
     },
     "enabled": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/enabled/-/enabled-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/enabled/-/enabled-2.0.0.tgz",
       "integrity": "sha1-+d2S7C1vS7wNXR5k4h1hzUZl58I="
     },
     "encodeurl": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/encodeurl/-/encodeurl-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "end-of-stream": {
       "version": "1.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
       "requires": {
         "once": "^1.4.0"
@@ -4155,7 +4267,7 @@
     },
     "engine.io": {
       "version": "3.4.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/engine.io/-/engine.io-3.4.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/engine.io/-/engine.io-3.4.2.tgz",
       "integrity": "sha1-j8hO4AOI4+IoZF4KfT367tW9Eiw=",
       "requires": {
         "accepts": "~1.3.4",
@@ -4168,58 +4280,63 @@
       "dependencies": {
         "cookie": {
           "version": "0.3.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cookie/-/cookie-0.3.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cookie/-/cookie-0.3.1.tgz",
           "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         }
       }
     },
     "engine.io-client": {
-      "version": "3.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/engine.io-client/-/engine.io-client-3.4.3.tgz",
-      "integrity": "sha1-GS0JhlQD4wl+NXXr/rOGHE0Bpmw=",
+      "version": "3.4.4",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/engine.io-client/-/engine.io-client-3.4.4.tgz",
+      "integrity": "sha1-d9gAP1ArB4LdeSsHOk0s98pauWc=",
       "requires": {
         "component-emitter": "~1.3.0",
         "component-inherit": "0.0.3",
-        "debug": "~4.1.0",
+        "debug": "~3.1.0",
         "engine.io-parser": "~2.2.0",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
+        "parseqs": "0.0.6",
+        "parseuri": "0.0.6",
         "ws": "~6.1.0",
         "xmlhttprequest-ssl": "~1.5.4",
         "yeast": "0.1.2"
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "version": "3.1.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.0.0"
           }
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+          "version": "2.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "parseqs": {
+          "version": "0.0.6",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parseqs/-/parseqs-0.0.6.tgz",
+          "integrity": "sha1-jku1oZ0c3IRKCKyXTTTic6+mcNU="
+        },
+        "parseuri": {
+          "version": "0.0.6",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parseuri/-/parseuri-0.0.6.tgz",
+          "integrity": "sha1-4Ulugp46wv9H85pN0ESzKCPEolo="
         },
         "ws": {
           "version": "6.1.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ws/-/ws-6.1.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ws/-/ws-6.1.4.tgz",
           "integrity": "sha1-W1yIAK+rkl6UzLKdFTyNAsF3bvk=",
           "requires": {
             "async-limiter": "~1.0.0"
@@ -4228,85 +4345,59 @@
       }
     },
     "engine.io-parser": {
-      "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/engine.io-parser/-/engine.io-parser-2.2.0.tgz",
-      "integrity": "sha1-MSxIlPV9UqArQgho2ntcHISvgO0=",
+      "version": "2.2.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/engine.io-parser/-/engine.io-parser-2.2.1.tgz",
+      "integrity": "sha1-V85WEdk3DulPmWQbWJ+UyX5PXac=",
       "requires": {
         "after": "0.8.2",
         "arraybuffer.slice": "~0.0.7",
-        "base64-arraybuffer": "0.1.5",
+        "base64-arraybuffer": "0.1.4",
         "blob": "0.0.5",
         "has-binary2": "~1.0.2"
       }
     },
     "enquirer": {
       "version": "2.3.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/enquirer/-/enquirer-2.3.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/enquirer/-/enquirer-2.3.6.tgz",
       "integrity": "sha1-Kn/l3WNKHkElqXXsmU/1RW3Dc00=",
       "requires": {
         "ansi-colors": "^4.1.1"
       }
     },
     "entities": {
-      "version": "2.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/entities/-/entities-2.0.3.tgz",
-      "integrity": "sha1-XEh+V0Krk8Fau12iJ1m4WQ7AO38="
+      "version": "2.1.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha1-mS0xKc999ocLlsV4WMJJoSD4uLU="
     },
     "error-ex": {
       "version": "1.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/error-ex/-/error-ex-1.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
       "requires": {
         "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
-      "version": "1.17.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/es-abstract/-/es-abstract-1.17.6.tgz",
-      "integrity": "sha1-kUIHFweFeyysx7iey2cDFsPi1So=",
+      "version": "1.17.7",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/es-abstract/-/es-abstract-1.17.7.tgz",
+      "integrity": "sha1-pN5hsvZpifx0IWdsHLl4dXOs5Uw=",
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.0",
-        "is-regex": "^1.1.0",
-        "object-inspect": "^1.7.0",
+        "is-callable": "^1.2.2",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.8.0",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.0",
+        "object.assign": "^4.1.1",
         "string.prototype.trimend": "^1.0.1",
         "string.prototype.trimstart": "^1.0.1"
       }
     },
-    "es-array-method-boxes-properly": {
-      "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-      "integrity": "sha1-hz8+hEGN5O4Zxb51KZCy5EcY0J4="
-    },
-    "es-get-iterator": {
-      "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/es-get-iterator/-/es-get-iterator-1.1.0.tgz",
-      "integrity": "sha1-u5itnW1jsxqs3I+J1dDuV7y1tMg=",
-      "requires": {
-        "es-abstract": "^1.17.4",
-        "has-symbols": "^1.0.1",
-        "is-arguments": "^1.0.4",
-        "is-map": "^2.0.1",
-        "is-set": "^2.0.1",
-        "is-string": "^1.0.5",
-        "isarray": "^2.0.5"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha1-ivHkwSISRMxiRZ+vOJQNTmRKVyM="
-        }
-      }
-    },
     "es-to-primitive": {
       "version": "1.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
       "requires": {
         "is-callable": "^1.1.4",
@@ -4316,32 +4407,37 @@
     },
     "es6-promise": {
       "version": "4.2.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/es6-promise/-/es6-promise-4.2.8.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/es6-promise/-/es6-promise-4.2.8.tgz",
       "integrity": "sha1-TrIVlMlyvEBVPSduUQU5FD21Pgo="
     },
     "es6-promisify": {
       "version": "6.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/es6-promisify/-/es6-promisify-6.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/es6-promisify/-/es6-promisify-6.1.1.tgz",
       "integrity": "sha1-RoN2Ubewa/b/+JPQPyk5NmjQFiE="
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA="
     },
     "escape-goat": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/escape-goat/-/escape-goat-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/escape-goat/-/escape-goat-3.0.0.tgz",
       "integrity": "sha1-6LX7ZYVT/oo8SVnDFsbruMhCsZw="
     },
     "escape-html": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.14.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/escodegen/-/escodegen-1.14.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/escodegen/-/escodegen-1.14.3.tgz",
       "integrity": "sha1-TnuB+6YVgdyXWC7XjKt/Do1j9QM=",
       "requires": {
         "esprima": "^4.0.1",
@@ -4353,7 +4449,7 @@
       "dependencies": {
         "levn": {
           "version": "0.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/levn/-/levn-0.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/levn/-/levn-0.3.0.tgz",
           "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
           "requires": {
             "prelude-ls": "~1.1.2",
@@ -4362,7 +4458,7 @@
         },
         "optionator": {
           "version": "0.8.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/optionator/-/optionator-0.8.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/optionator/-/optionator-0.8.3.tgz",
           "integrity": "sha1-hPodA2/p08fiHZmIS2ARZ+yPtJU=",
           "requires": {
             "deep-is": "~0.1.3",
@@ -4375,12 +4471,12 @@
         },
         "prelude-ls": {
           "version": "1.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/prelude-ls/-/prelude-ls-1.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/prelude-ls/-/prelude-ls-1.1.2.tgz",
           "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
         },
         "type-check": {
           "version": "0.3.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-check/-/type-check-0.3.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-check/-/type-check-0.3.2.tgz",
           "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
           "requires": {
             "prelude-ls": "~1.1.2"
@@ -4389,9 +4485,9 @@
       }
     },
     "eslint": {
-      "version": "7.9.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eslint/-/eslint-7.9.0.tgz",
-      "integrity": "sha1-UirszFw6GQF88MtG6/1mCnms8zc=",
+      "version": "7.11.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/eslint/-/eslint-7.11.0.tgz",
+      "integrity": "sha1-qvLSOgtfHWUqCO2s6gwZ9/rcCzs=",
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@eslint/eslintrc": "^0.1.3",
@@ -4401,9 +4497,9 @@
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
         "enquirer": "^2.3.5",
-        "eslint-scope": "^5.1.0",
+        "eslint-scope": "^5.1.1",
         "eslint-utils": "^2.1.0",
-        "eslint-visitor-keys": "^1.3.0",
+        "eslint-visitor-keys": "^2.0.0",
         "espree": "^7.3.0",
         "esquery": "^1.2.0",
         "esutils": "^2.0.2",
@@ -4434,35 +4530,22 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U="
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-          "requires": {
-            "ms": "^2.1.1"
-          }
         },
         "ignore": {
           "version": "4.0.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ignore/-/ignore-4.0.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw="
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         },
         "semver": {
           "version": "7.3.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-7.3.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/semver/-/semver-7.3.2.tgz",
           "integrity": "sha1-YElisFK4HtB4aq6EOJ/7pw/9OTg="
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
           "requires": {
             "ansi-regex": "^5.0.0"
@@ -4472,12 +4555,12 @@
     },
     "eslint-config-google": {
       "version": "0.14.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eslint-config-google/-/eslint-config-google-0.14.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/eslint-config-google/-/eslint-config-google-0.14.0.tgz",
       "integrity": "sha1-T1+HWbpuEbQkKUohnb+hjFCLzBo="
     },
     "eslint-plugin-html": {
       "version": "6.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eslint-plugin-html/-/eslint-plugin-html-6.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/eslint-plugin-html/-/eslint-plugin-html-6.1.0.tgz",
       "integrity": "sha1-Dg1IRdSz624ZllI4Xicve3Imc9s=",
       "requires": {
         "htmlparser2": "^4.1.0"
@@ -4485,12 +4568,12 @@
     },
     "eslint-plugin-only-warn": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eslint-plugin-only-warn/-/eslint-plugin-only-warn-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/eslint-plugin-only-warn/-/eslint-plugin-only-warn-1.0.2.tgz",
       "integrity": "sha1-Ir886fCoZx7s94dX1u/z/VGL4Ko="
     },
     "eslint-scope": {
       "version": "5.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha1-54blmmbLkrP2wfsNUIqrF0hI9Iw=",
       "requires": {
         "esrecurse": "^4.3.0",
@@ -4499,35 +4582,49 @@
     },
     "eslint-utils": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/eslint-utils/-/eslint-utils-2.1.0.tgz",
       "integrity": "sha1-0t5eA0JOcH3BDHQGjd7a5wh0Gyc=",
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha1-MOvR73wv3/AcOk8VEESvJfqwUj4="
+        }
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha1-MOvR73wv3/AcOk8VEESvJfqwUj4="
+      "version": "2.0.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+      "integrity": "sha1-If3I+82ceVzAMh8FY3AglXUVEag="
     },
     "espree": {
       "version": "7.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/espree/-/espree-7.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/espree/-/espree-7.3.0.tgz",
       "integrity": "sha1-3DBDfPZ5R89XYSHr14DxXurHI0g=",
       "requires": {
         "acorn": "^7.4.0",
         "acorn-jsx": "^5.2.0",
         "eslint-visitor-keys": "^1.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha1-MOvR73wv3/AcOk8VEESvJfqwUj4="
+        }
       }
     },
     "esprima": {
       "version": "4.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/esprima/-/esprima-4.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
     },
     "esquery": {
       "version": "1.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/esquery/-/esquery-1.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/esquery/-/esquery-1.3.1.tgz",
       "integrity": "sha1-t4tYKKqOIU4p+3TE1bdS4cAz2lc=",
       "requires": {
         "estraverse": "^5.1.0"
@@ -4535,14 +4632,14 @@
       "dependencies": {
         "estraverse": {
           "version": "5.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/estraverse/-/estraverse-5.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/estraverse/-/estraverse-5.2.0.tgz",
           "integrity": "sha1-MH30JUfmzHMk088DwVXVzbjFOIA="
         }
       }
     },
     "esrecurse": {
       "version": "4.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/esrecurse/-/esrecurse-4.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
       "requires": {
         "estraverse": "^5.2.0"
@@ -4550,29 +4647,29 @@
       "dependencies": {
         "estraverse": {
           "version": "5.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/estraverse/-/estraverse-5.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/estraverse/-/estraverse-5.2.0.tgz",
           "integrity": "sha1-MH30JUfmzHMk088DwVXVzbjFOIA="
         }
       }
     },
     "estraverse": {
       "version": "4.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/estraverse/-/estraverse-4.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0="
     },
     "esutils": {
       "version": "2.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/esutils/-/esutils-2.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q="
     },
     "etag": {
       "version": "1.8.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/etag/-/etag-1.8.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "event-stream": {
       "version": "4.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/event-stream/-/event-stream-4.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/event-stream/-/event-stream-4.0.1.tgz",
       "integrity": "sha1-QJKAjsmV0N116kWAwd9qdNss3mU=",
       "requires": {
         "duplexer": "^0.1.1",
@@ -4582,16 +4679,40 @@
         "split": "^1.0.1",
         "stream-combiner": "^0.2.2",
         "through": "^2.3.8"
+      },
+      "dependencies": {
+        "map-stream": {
+          "version": "0.0.7",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/map-stream/-/map-stream-0.0.7.tgz",
+          "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg="
+        },
+        "split": {
+          "version": "1.0.1",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/split/-/split-1.0.1.tgz",
+          "integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
+          "requires": {
+            "through": "2"
+          }
+        },
+        "stream-combiner": {
+          "version": "0.2.2",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/stream-combiner/-/stream-combiner-0.2.2.tgz",
+          "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
+          "requires": {
+            "duplexer": "~0.1.1",
+            "through": "~2.3.4"
+          }
+        }
       }
     },
     "eventemitter3": {
       "version": "4.0.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha1-Lem2j2Uo1WRO9cWVJqG0oHMGFp8="
     },
     "execa": {
       "version": "4.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/execa/-/execa-4.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/execa/-/execa-4.0.3.tgz",
       "integrity": "sha1-CjTau61tZhAL1vLFdshmlAPzF/I=",
       "requires": {
         "cross-spawn": "^7.0.0",
@@ -4607,14 +4728,14 @@
       "dependencies": {
         "is-stream": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-stream/-/is-stream-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-stream/-/is-stream-2.0.0.tgz",
           "integrity": "sha1-venDJoDW+uBBKdasnZIc54FfeOM="
         }
       }
     },
     "expand-brackets": {
       "version": "2.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "requires": {
         "debug": "^2.3.3",
@@ -4628,7 +4749,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
@@ -4636,7 +4757,7 @@
         },
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -4644,17 +4765,22 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
     "expand-range": {
       "version": "1.8.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/expand-range/-/expand-range-1.8.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "requires": {
         "fill-range": "^2.1.0"
@@ -4662,7 +4788,7 @@
       "dependencies": {
         "fill-range": {
           "version": "2.2.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fill-range/-/fill-range-2.2.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fill-range/-/fill-range-2.2.4.tgz",
           "integrity": "sha1-6x53OrsFbc2N8r/favWbizqTZWU=",
           "requires": {
             "is-number": "^2.1.0",
@@ -4672,14 +4798,9 @@
             "repeat-string": "^1.5.2"
           }
         },
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
-        },
         "is-number": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-number/-/is-number-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-number/-/is-number-2.1.0.tgz",
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "requires": {
             "kind-of": "^3.0.2"
@@ -4687,12 +4808,12 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "isobject": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isobject/-/isobject-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isobject/-/isobject-2.1.0.tgz",
           "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
           "requires": {
             "isarray": "1.0.0"
@@ -4700,7 +4821,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -4710,7 +4831,7 @@
     },
     "expand-tilde": {
       "version": "2.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/expand-tilde/-/expand-tilde-2.0.2.tgz",
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "requires": {
         "homedir-polyfill": "^1.0.1"
@@ -4718,7 +4839,7 @@
     },
     "express": {
       "version": "4.17.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/express/-/express-4.17.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/express/-/express-4.17.1.tgz",
       "integrity": "sha1-RJH8OGBc9R+GKdOcK10Cb5ikwTQ=",
       "requires": {
         "accepts": "~1.3.7",
@@ -4755,25 +4876,30 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
           }
         },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
         "path-to-regexp": {
           "version": "0.1.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
           "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
         },
         "qs": {
           "version": "6.7.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/qs/-/qs-6.7.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/qs/-/qs-6.7.0.tgz",
           "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw="
         },
         "send": {
           "version": "0.17.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/send/-/send-0.17.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/send/-/send-0.17.1.tgz",
           "integrity": "sha1-wdiwWfeQD3Rm3Uk4vcROEd2zdsg=",
           "requires": {
             "debug": "2.6.9",
@@ -4793,7 +4919,7 @@
           "dependencies": {
             "ms": {
               "version": "2.1.1",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.1.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.1.tgz",
               "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
             }
           }
@@ -4802,12 +4928,12 @@
     },
     "extend": {
       "version": "3.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend/-/extend-3.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend/-/extend-3.0.2.tgz",
       "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
     },
     "extend-shallow": {
       "version": "3.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "requires": {
         "assign-symbols": "^1.0.0",
@@ -4816,7 +4942,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extendable/-/is-extendable-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "requires": {
             "is-plain-object": "^2.0.4"
@@ -4826,7 +4952,7 @@
     },
     "external-editor": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/external-editor/-/external-editor-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/external-editor/-/external-editor-3.1.0.tgz",
       "integrity": "sha1-ywP3QL764D6k0oPK7SdBqD8zVJU=",
       "requires": {
         "chardet": "^0.7.0",
@@ -4836,7 +4962,7 @@
     },
     "extglob": {
       "version": "2.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extglob/-/extglob-2.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extglob/-/extglob-2.0.4.tgz",
       "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
       "requires": {
         "array-unique": "^0.3.2",
@@ -4851,7 +4977,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
             "is-descriptor": "^1.0.0"
@@ -4859,7 +4985,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -4867,7 +4993,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "requires": {
             "kind-of": "^6.0.0"
@@ -4875,7 +5001,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "requires": {
             "kind-of": "^6.0.0"
@@ -4883,7 +5009,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -4895,43 +5021,28 @@
     },
     "extract-zip": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extract-zip/-/extract-zip-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha1-Zj3KVv5G34kNXxMe9KBtIruLoTo=",
       "requires": {
         "@types/yauzl": "^2.9.1",
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
-        }
       }
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU="
     },
     "fast-glob": {
       "version": "3.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fast-glob/-/fast-glob-3.2.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fast-glob/-/fast-glob-3.2.4.tgz",
       "integrity": "sha1-0grvv5lXk4Pn88xmUpFYybmFVNM=",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -4944,22 +5055,22 @@
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fast-safe-stringify": {
       "version": "2.0.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
       "integrity": "sha1-EkqohYmSYfaK7bQqfAgN6dpgh0M="
     },
     "fastq": {
       "version": "1.8.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fastq/-/fastq-1.8.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fastq/-/fastq-1.8.0.tgz",
       "integrity": "sha1-VQ4fn1m7xl/hhctqm02VNXEH9IE=",
       "requires": {
         "reusify": "^1.0.4"
@@ -4967,7 +5078,7 @@
     },
     "fd-slicer": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "requires": {
         "pend": "~1.2.0"
@@ -4975,12 +5086,12 @@
     },
     "fecha": {
       "version": "2.3.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fecha/-/fecha-2.3.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha1-lI50FX3xoy/RsSw6PDzctuydls0="
     },
     "fetch-mock": {
       "version": "9.10.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fetch-mock/-/fetch-mock-9.10.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fetch-mock/-/fetch-mock-9.10.7.tgz",
       "integrity": "sha1-lnNxevGB4ey3kc8yMVwTWA1Fceo=",
       "requires": {
         "babel-runtime": "^6.26.0",
@@ -4992,26 +5103,11 @@
         "path-to-regexp": "^2.2.1",
         "querystring": "^0.2.0",
         "whatwg-url": "^6.5.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
-        }
       }
     },
     "figures": {
       "version": "3.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/figures/-/figures-3.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/figures/-/figures-3.2.0.tgz",
       "integrity": "sha1-YlwYvSk8YE3EqN2y/r8MiDQXRq8=",
       "requires": {
         "escape-string-regexp": "^1.0.5"
@@ -5019,7 +5115,7 @@
     },
     "file-entry-cache": {
       "version": "5.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
       "integrity": "sha1-yg9u+m3T1WEzP7FFFQZcL6/fQ5w=",
       "requires": {
         "flat-cache": "^2.0.1"
@@ -5027,17 +5123,17 @@
     },
     "file-uri-to-path": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90="
     },
     "filename-regex": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/filename-regex/-/filename-regex-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/filename-regex/-/filename-regex-2.0.1.tgz",
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
     },
     "fill-range": {
       "version": "7.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fill-range/-/fill-range-7.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
       "requires": {
         "to-regex-range": "^5.0.1"
@@ -5045,7 +5141,7 @@
     },
     "finalhandler": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/finalhandler/-/finalhandler-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/finalhandler/-/finalhandler-1.1.2.tgz",
       "integrity": "sha1-t+fQAP/RGTjQ/bBTUG9uur6fWH0=",
       "requires": {
         "debug": "2.6.9",
@@ -5059,17 +5155,22 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
     "find-port": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-port/-/find-port-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/find-port/-/find-port-1.0.1.tgz",
       "integrity": "sha1-2whKbL+ZVk2Zhprnn73s9m6KGFw=",
       "requires": {
         "async": "~0.2.9"
@@ -5077,14 +5178,14 @@
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-0.2.10.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/async/-/async-0.2.10.tgz",
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
         }
       }
     },
     "find-replace": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-replace/-/find-replace-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/find-replace/-/find-replace-3.0.0.tgz",
       "integrity": "sha1-Pn4j07BRZ6dvdwyfvVJYsN72jDg=",
       "requires": {
         "array-back": "^3.0.1"
@@ -5092,7 +5193,7 @@
     },
     "find-up": {
       "version": "5.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-up/-/find-up-5.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha1-TJKBnstwg1YeT0okCoa+UZj1Nvw=",
       "requires": {
         "locate-path": "^6.0.0",
@@ -5101,7 +5202,7 @@
     },
     "findup-sync": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/findup-sync/-/findup-sync-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/findup-sync/-/findup-sync-2.0.0.tgz",
       "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "requires": {
         "detect-file": "^1.0.0",
@@ -5112,7 +5213,7 @@
       "dependencies": {
         "braces": {
           "version": "2.3.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/braces/-/braces-2.3.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/braces/-/braces-2.3.2.tgz",
           "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
           "requires": {
             "arr-flatten": "^1.1.0",
@@ -5129,7 +5230,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -5139,7 +5240,7 @@
         },
         "fill-range": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fill-range/-/fill-range-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "requires": {
             "extend-shallow": "^2.0.1",
@@ -5150,7 +5251,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -5158,14 +5259,9 @@
             }
           }
         },
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
-        },
         "is-glob": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
             "is-extglob": "^2.1.0"
@@ -5173,7 +5269,7 @@
         },
         "is-number": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-number/-/is-number-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
             "kind-of": "^3.0.2"
@@ -5181,7 +5277,7 @@
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
                 "is-buffer": "^1.1.5"
@@ -5191,7 +5287,7 @@
         },
         "micromatch": {
           "version": "3.1.10",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/micromatch/-/micromatch-3.1.10.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
           "requires": {
             "arr-diff": "^4.0.0",
@@ -5211,7 +5307,7 @@
         },
         "to-regex-range": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
           "requires": {
             "is-number": "^3.0.0",
@@ -5222,20 +5318,17 @@
     },
     "first-chunk-stream": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
       "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
     },
     "flat": {
-      "version": "4.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/flat/-/flat-4.1.0.tgz",
-      "integrity": "sha1-CQvsiwXjnLowl0fx1YjwTbr5jbI=",
-      "requires": {
-        "is-buffer": "~2.0.3"
-      }
+      "version": "5.0.2",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha1-jKb+MyBp/6nTJMMnGYxZglnOskE="
     },
     "flat-cache": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/flat-cache/-/flat-cache-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/flat-cache/-/flat-cache-2.0.1.tgz",
       "integrity": "sha1-XSltbwS9pEpGMKMBQTvbwuwIXsA=",
       "requires": {
         "flatted": "^2.0.0",
@@ -5245,7 +5338,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.6.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rimraf/-/rimraf-2.6.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/rimraf/-/rimraf-2.6.3.tgz",
           "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
           "requires": {
             "glob": "^7.1.3"
@@ -5255,35 +5348,50 @@
     },
     "flatpickr": {
       "version": "4.6.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/flatpickr/-/flatpickr-4.6.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/flatpickr/-/flatpickr-4.6.2.tgz",
       "integrity": "sha1-UOG0/IT79nxbCRm6PdwzAiHxJto="
     },
     "flatted": {
       "version": "2.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/flatted/-/flatted-2.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha1-RXWyHivO50NKqb5mL0t7X5wrUTg="
     },
     "fn.name": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fn.name/-/fn.name-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha1-JsrYAXlnrqhzG8QpYdBKPVmIrMw="
     },
     "follow-redirects": {
       "version": "1.5.10",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/follow-redirects/-/follow-redirects-1.5.10.tgz",
       "integrity": "sha1-e3qfmuov3/NnhqlP9kPtB/T/Xio=",
       "requires": {
         "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/for-in/-/for-in-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
     },
     "for-own": {
       "version": "0.1.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/for-own/-/for-own-0.1.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "requires": {
         "for-in": "^1.0.1"
@@ -5291,22 +5399,22 @@
     },
     "foreach": {
       "version": "2.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/foreach/-/foreach-2.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/foreach/-/foreach-2.0.5.tgz",
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "fork-stream": {
       "version": "0.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fork-stream/-/fork-stream-0.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fork-stream/-/fork-stream-0.0.4.tgz",
       "integrity": "sha1-24Sfznf2cIpfjzhq5TOgkHtUrnA="
     },
     "form-data": {
       "version": "2.3.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/form-data/-/form-data-2.3.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
       "requires": {
         "asynckit": "^0.4.0",
@@ -5316,7 +5424,7 @@
     },
     "formatio": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/formatio/-/formatio-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/formatio/-/formatio-1.1.1.tgz",
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "requires": {
         "samsam": "~1.1"
@@ -5324,12 +5432,12 @@
     },
     "forwarded": {
       "version": "0.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/forwarded/-/forwarded-0.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/forwarded/-/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
     "fragment-cache": {
       "version": "0.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "requires": {
         "map-cache": "^0.2.2"
@@ -5337,28 +5445,28 @@
     },
     "freeport": {
       "version": "1.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/freeport/-/freeport-1.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/freeport/-/freeport-1.0.5.tgz",
       "integrity": "sha1-JV6KuEFwwzuoXZkOghrl9KGpvF0=",
       "optional": true
     },
     "fresh": {
       "version": "0.5.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fresh/-/fresh-0.5.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "from": {
       "version": "0.1.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/from/-/from-0.1.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/from/-/from-0.1.7.tgz",
       "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
     },
     "fs-constants": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fs-constants/-/fs-constants-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0="
     },
     "fs-minipass": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha1-f1A2/b8SxjwWkZDL5BmchSJx+fs=",
       "requires": {
         "minipass": "^3.0.0"
@@ -5366,18 +5474,18 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "2.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fsevents/-/fsevents-2.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fsevents/-/fsevents-2.1.3.tgz",
       "integrity": "sha1-+3OHA66NL5/pAMM4Nt3r7ouX8j4=",
       "optional": true
     },
     "fstream": {
       "version": "1.0.12",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fstream/-/fstream-1.0.12.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fstream/-/fstream-1.0.12.tgz",
       "integrity": "sha1-Touo7i1Ivk99DeUFRVVI6uWTIEU=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -5388,22 +5496,22 @@
     },
     "function-bind": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/function-bind/-/function-bind-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "fuse.js": {
       "version": "2.7.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fuse.js/-/fuse.js-2.7.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fuse.js/-/fuse.js-2.7.4.tgz",
       "integrity": "sha1-luQg/efvARrEnCWKYhMU/ldlNvk="
     },
     "gauge": {
       "version": "2.7.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/gauge/-/gauge-2.7.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "requires": {
         "aproba": "^1.0.3",
@@ -5418,7 +5526,7 @@
     },
     "geckodriver": {
       "version": "1.20.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/geckodriver/-/geckodriver-1.20.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/geckodriver/-/geckodriver-1.20.0.tgz",
       "integrity": "sha1-zRbtsXe4jjGv/LVLGKI4yuiJUKc=",
       "requires": {
         "adm-zip": "0.4.16",
@@ -5428,14 +5536,31 @@
         "tar": "6.0.2"
       },
       "dependencies": {
+        "agent-base": {
+          "version": "6.0.1",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/agent-base/-/agent-base-6.0.1.tgz",
+          "integrity": "sha1-gIAH5OWGfeywq2qy+Sj721pZbbQ=",
+          "requires": {
+            "debug": "4"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha1-4qkFQqu2inYuCghQ9sntrf2FBrI=",
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
         "mkdirp": {
           "version": "1.0.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mkdirp/-/mkdirp-1.0.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34="
         },
         "tar": {
           "version": "6.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tar/-/tar-6.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tar/-/tar-6.0.2.tgz",
           "integrity": "sha1-XfF4E0aKYmT/FPdmiGxiK4SuLzk=",
           "requires": {
             "chownr": "^2.0.0",
@@ -5450,27 +5575,27 @@
     },
     "gensync": {
       "version": "1.0.0-beta.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/gensync/-/gensync-1.0.0-beta.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/gensync/-/gensync-1.0.0-beta.1.tgz",
       "integrity": "sha1-WPQ2H/mH5f9uHnohCCeqNx6qwmk="
     },
     "get-caller-file": {
       "version": "2.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34="
     },
     "get-func-name": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-func-name/-/get-func-name-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
     },
     "get-stdin": {
       "version": "4.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-stdin/-/get-stdin-4.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-stdin/-/get-stdin-4.0.1.tgz",
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
     },
     "get-stream": {
       "version": "5.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-stream/-/get-stream-5.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha1-SWaheV7lrOZecGxLe+txJX1uItM=",
       "requires": {
         "pump": "^3.0.0"
@@ -5478,12 +5603,12 @@
     },
     "get-value": {
       "version": "2.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-value/-/get-value-2.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -5491,12 +5616,12 @@
     },
     "github-url-from-git": {
       "version": "1.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
       "integrity": "sha1-+YX+3MCpqledyI16/waNVcxiUaA="
     },
     "glob": {
       "version": "7.1.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob/-/glob-7.1.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob/-/glob-7.1.6.tgz",
       "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -5509,7 +5634,7 @@
     },
     "glob-base": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-base/-/glob-base-0.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "requires": {
         "glob-parent": "^2.0.0",
@@ -5518,7 +5643,7 @@
       "dependencies": {
         "glob-parent": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-parent/-/glob-parent-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob-parent/-/glob-parent-2.0.0.tgz",
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "requires": {
             "is-glob": "^2.0.0"
@@ -5526,12 +5651,12 @@
         },
         "is-extglob": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
         },
         "is-glob": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "requires": {
             "is-extglob": "^1.0.0"
@@ -5541,7 +5666,7 @@
     },
     "glob-parent": {
       "version": "5.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-parent/-/glob-parent-5.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob-parent/-/glob-parent-5.1.1.tgz",
       "integrity": "sha1-tsHvQXxOVmPqSY8cRa+saRa7wik=",
       "requires": {
         "is-glob": "^4.0.1"
@@ -5549,7 +5674,7 @@
     },
     "glob-stream": {
       "version": "5.3.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-stream/-/glob-stream-5.3.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob-stream/-/glob-stream-5.3.5.tgz",
       "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
       "requires": {
         "extend": "^3.0.0",
@@ -5564,7 +5689,7 @@
       "dependencies": {
         "arr-diff": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arr-diff/-/arr-diff-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/arr-diff/-/arr-diff-2.0.0.tgz",
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "requires": {
             "arr-flatten": "^1.0.1"
@@ -5572,12 +5697,12 @@
         },
         "array-unique": {
           "version": "0.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-unique/-/array-unique-0.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-unique/-/array-unique-0.2.1.tgz",
           "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
         },
         "braces": {
           "version": "1.8.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/braces/-/braces-1.8.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/braces/-/braces-1.8.5.tgz",
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "requires": {
             "expand-range": "^1.8.1",
@@ -5587,7 +5712,7 @@
         },
         "expand-brackets": {
           "version": "0.1.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/expand-brackets/-/expand-brackets-0.1.5.tgz",
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "requires": {
             "is-posix-bracket": "^0.1.0"
@@ -5595,7 +5720,7 @@
         },
         "extglob": {
           "version": "0.3.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extglob/-/extglob-0.3.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extglob/-/extglob-0.3.2.tgz",
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "requires": {
             "is-extglob": "^1.0.0"
@@ -5603,14 +5728,14 @@
           "dependencies": {
             "is-extglob": {
               "version": "1.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
               "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
             }
           }
         },
         "glob": {
           "version": "5.0.15",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob/-/glob-5.0.15.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "requires": {
             "inflight": "^1.0.4",
@@ -5622,21 +5747,16 @@
         },
         "glob-parent": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-parent/-/glob-parent-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "requires": {
             "is-glob": "^3.1.0",
             "path-dirname": "^1.0.0"
           }
         },
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
-        },
         "is-glob": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
             "is-extglob": "^2.1.0"
@@ -5644,7 +5764,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -5652,7 +5772,7 @@
         },
         "micromatch": {
           "version": "2.3.11",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/micromatch/-/micromatch-2.3.11.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/micromatch/-/micromatch-2.3.11.tgz",
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "requires": {
             "arr-diff": "^2.0.0",
@@ -5672,12 +5792,12 @@
           "dependencies": {
             "is-extglob": {
               "version": "1.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
               "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
             },
             "is-glob": {
               "version": "2.0.1",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "requires": {
                 "is-extglob": "^1.0.0"
@@ -5687,7 +5807,7 @@
         },
         "normalize-path": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-path/-/normalize-path-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "requires": {
             "remove-trailing-separator": "^1.0.1"
@@ -5695,7 +5815,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -5706,7 +5826,7 @@
         },
         "through2": {
           "version": "0.6.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through2/-/through2-0.6.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
             "readable-stream": ">=1.0.33-1 <1.1.0-0",
@@ -5717,12 +5837,12 @@
     },
     "glob-to-regexp": {
       "version": "0.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha1-x1KXCHyFG5pXi9IX3VmpL1n+VG4="
     },
     "global-dirs": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/global-dirs/-/global-dirs-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/global-dirs/-/global-dirs-2.0.1.tgz",
       "integrity": "sha1-rN87tmhbzVXLNeigUiZlaelGkgE=",
       "requires": {
         "ini": "^1.3.5"
@@ -5730,7 +5850,7 @@
     },
     "global-modules": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/global-modules/-/global-modules-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/global-modules/-/global-modules-1.0.0.tgz",
       "integrity": "sha1-bXcPDrUjrHgWTXK15xqIdyZcw+o=",
       "requires": {
         "global-prefix": "^1.0.1",
@@ -5740,7 +5860,7 @@
     },
     "global-prefix": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/global-prefix/-/global-prefix-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/global-prefix/-/global-prefix-1.0.2.tgz",
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "requires": {
         "expand-tilde": "^2.0.2",
@@ -5752,7 +5872,7 @@
     },
     "globals": {
       "version": "12.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/globals/-/globals-12.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/globals/-/globals-12.4.0.tgz",
       "integrity": "sha1-oYgTV2pBsAokqX5/gVkYwuGZJfg=",
       "requires": {
         "type-fest": "^0.8.1"
@@ -5760,7 +5880,7 @@
     },
     "globby": {
       "version": "10.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/globby/-/globby-10.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/globby/-/globby-10.0.2.tgz",
       "integrity": "sha1-J3WT50WsqkZGw6tBEonsR6A5JUM=",
       "requires": {
         "@types/glob": "^7.1.1",
@@ -5775,7 +5895,7 @@
     },
     "good-listener": {
       "version": "1.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/good-listener/-/good-listener-1.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
       "requires": {
         "delegate": "^3.1.2"
@@ -5783,7 +5903,7 @@
     },
     "got": {
       "version": "5.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/got/-/got-5.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/got/-/got-5.6.0.tgz",
       "integrity": "sha1-ux1+4WO3gIK7yOuDbz85UATqb78=",
       "requires": {
         "create-error-class": "^3.0.1",
@@ -5806,22 +5926,22 @@
     },
     "graceful-fs": {
       "version": "4.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha1-Ila94U02MpWMRl68ltxGfKB6Kfs="
     },
     "graceful-readlink": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
     "growl": {
       "version": "1.10.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/growl/-/growl-1.10.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/growl/-/growl-1.10.5.tgz",
       "integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4="
     },
     "gulp-if": {
       "version": "2.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/gulp-if/-/gulp-if-2.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/gulp-if/-/gulp-if-2.0.2.tgz",
       "integrity": "sha1-pJe351cwBQQcqivIt92jyARE1ik=",
       "requires": {
         "gulp-match": "^1.0.3",
@@ -5831,7 +5951,7 @@
     },
     "gulp-match": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/gulp-match/-/gulp-match-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/gulp-match/-/gulp-match-1.1.0.tgz",
       "integrity": "sha1-VStwgPwAbudSyQVj+f7J1hqv308=",
       "requires": {
         "minimatch": "^3.0.3"
@@ -5839,7 +5959,7 @@
     },
     "gulp-sourcemaps": {
       "version": "1.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
       "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
       "requires": {
         "convert-source-map": "^1.1.1",
@@ -5851,12 +5971,12 @@
     },
     "handle-thing": {
       "version": "1.2.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/handle-thing/-/handle-thing-1.2.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/handle-thing/-/handle-thing-1.2.5.tgz",
       "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
     },
     "handlebars": {
       "version": "4.7.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/handlebars/-/handlebars-4.7.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/handlebars/-/handlebars-4.7.6.tgz",
       "integrity": "sha1-1MBcG6+Q6ZRfd6pop6IZqkp9904=",
       "requires": {
         "minimist": "^1.2.5",
@@ -5868,12 +5988,12 @@
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.1.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/har-validator/-/har-validator-5.1.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/har-validator/-/har-validator-5.1.5.tgz",
       "integrity": "sha1-HwgDufjLIMD6E4It8ezds2veHv0=",
       "requires": {
         "ajv": "^6.12.3",
@@ -5882,12 +6002,12 @@
     },
     "hard-rejection": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/hard-rejection/-/hard-rejection-2.1.0.tgz",
       "integrity": "sha1-HG7aXBaFxjlCdm15u0Cudzzs2IM="
     },
     "has": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has/-/has-1.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has/-/has-1.0.3.tgz",
       "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
       "requires": {
         "function-bind": "^1.1.1"
@@ -5895,7 +6015,7 @@
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-ansi/-/has-ansi-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -5903,7 +6023,7 @@
     },
     "has-binary2": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-binary2/-/has-binary2-1.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-binary2/-/has-binary2-1.0.3.tgz",
       "integrity": "sha1-d3asYn8+p3JQz8My2rfd9eT10R0=",
       "requires": {
         "isarray": "2.0.1"
@@ -5911,39 +6031,39 @@
       "dependencies": {
         "isarray": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
         }
       }
     },
     "has-color": {
       "version": "0.1.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-color/-/has-color-0.1.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-color/-/has-color-0.1.7.tgz",
       "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
     },
     "has-cors": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-cors/-/has-cors-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-cors/-/has-cors-1.1.0.tgz",
       "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-symbols/-/has-symbols-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha1-n1IUdYpEGWxAbZvXbOv4HsLdMeg="
     },
     "has-unicode": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-unicode/-/has-unicode-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "has-value": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-value/-/has-value-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "requires": {
         "get-value": "^2.0.6",
@@ -5953,21 +6073,16 @@
     },
     "has-values": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-values/-/has-values-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "requires": {
         "is-number": "^3.0.0",
         "kind-of": "^4.0.0"
       },
       "dependencies": {
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
-        },
         "is-number": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-number/-/is-number-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
             "kind-of": "^3.0.2"
@@ -5975,7 +6090,7 @@
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
                 "is-buffer": "^1.1.5"
@@ -5985,7 +6100,7 @@
         },
         "kind-of": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -5995,33 +6110,33 @@
     },
     "has-yarn": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-yarn/-/has-yarn-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-yarn/-/has-yarn-2.1.0.tgz",
       "integrity": "sha1-E34RNUp7W/EapctknPDG8/8rLnc="
     },
     "he": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/he/-/he-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/he/-/he-1.2.0.tgz",
       "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8="
     },
     "homedir-polyfill": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
       "integrity": "sha1-dDKYzvTlrz4ZQWH7rcwhUdOgWOg=",
       "requires": {
         "parse-passwd": "^1.0.0"
       }
     },
     "hosted-git-info": {
-      "version": "3.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/hosted-git-info/-/hosted-git-info-3.0.5.tgz",
-      "integrity": "sha1-vqh5Be9zF0QujfMIf6o8hCOX3wM=",
+      "version": "3.0.7",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
+      "integrity": "sha1-owcnOF6oWs/O6U4KrZ42jHkuA2w=",
       "requires": {
         "lru-cache": "^6.0.0"
       }
     },
     "hpack.js": {
       "version": "2.1.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/hpack.js/-/hpack.js-2.1.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/hpack.js/-/hpack.js-2.1.6.tgz",
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "requires": {
         "inherits": "^2.0.1",
@@ -6032,7 +6147,7 @@
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
       "integrity": "sha1-QqbcT9M/ACgRduiyN1nKTk+hhfM=",
       "requires": {
         "whatwg-encoding": "^1.0.5"
@@ -6040,7 +6155,7 @@
     },
     "html-minifier": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/html-minifier/-/html-minifier-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/html-minifier/-/html-minifier-4.0.0.tgz",
       "integrity": "sha1-zKmq2LzhF14C4XqMM+RtiYiIn1Y=",
       "requires": {
         "camel-case": "^3.0.0",
@@ -6054,7 +6169,7 @@
     },
     "htmlparser2": {
       "version": "4.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/htmlparser2/-/htmlparser2-4.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/htmlparser2/-/htmlparser2-4.1.0.tgz",
       "integrity": "sha1-mk7xYfLkYl6/ffvmwKL1LRilnng=",
       "requires": {
         "domelementtype": "^2.0.1",
@@ -6065,17 +6180,17 @@
     },
     "http-cache-semantics": {
       "version": "4.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
       "integrity": "sha1-SekcXL82yblLz81xwj1SSex045A="
     },
     "http-deceiver": {
       "version": "1.2.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-deceiver/-/http-deceiver-1.2.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/http-deceiver/-/http-deceiver-1.2.7.tgz",
       "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
     },
     "http-errors": {
       "version": "1.7.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-errors/-/http-errors-1.7.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/http-errors/-/http-errors-1.7.2.tgz",
       "integrity": "sha1-T1ApzxMjnzEDblsuVSkrz7zIXI8=",
       "requires": {
         "depd": "~1.1.2",
@@ -6087,14 +6202,14 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inherits/-/inherits-2.0.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         }
       }
     },
     "http-proxy": {
       "version": "1.18.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-proxy/-/http-proxy-1.18.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/http-proxy/-/http-proxy-1.18.1.tgz",
       "integrity": "sha1-QBVB8FNIhLv5UmAzTnL4juOXZUk=",
       "requires": {
         "eventemitter3": "^4.0.0",
@@ -6104,7 +6219,7 @@
     },
     "http-proxy-middleware": {
       "version": "0.17.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
       "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
       "requires": {
         "http-proxy": "^1.16.2",
@@ -6115,7 +6230,7 @@
       "dependencies": {
         "arr-diff": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arr-diff/-/arr-diff-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/arr-diff/-/arr-diff-2.0.0.tgz",
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "requires": {
             "arr-flatten": "^1.0.1"
@@ -6123,12 +6238,12 @@
         },
         "array-unique": {
           "version": "0.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-unique/-/array-unique-0.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-unique/-/array-unique-0.2.1.tgz",
           "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
         },
         "braces": {
           "version": "1.8.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/braces/-/braces-1.8.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/braces/-/braces-1.8.5.tgz",
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "requires": {
             "expand-range": "^1.8.1",
@@ -6138,7 +6253,7 @@
         },
         "expand-brackets": {
           "version": "0.1.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/expand-brackets/-/expand-brackets-0.1.5.tgz",
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "requires": {
             "is-posix-bracket": "^0.1.0"
@@ -6146,7 +6261,7 @@
         },
         "extglob": {
           "version": "0.3.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extglob/-/extglob-0.3.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extglob/-/extglob-0.3.2.tgz",
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "requires": {
             "is-extglob": "^1.0.0"
@@ -6154,19 +6269,14 @@
           "dependencies": {
             "is-extglob": {
               "version": "1.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
               "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
             }
           }
         },
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
-        },
         "is-glob": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
             "is-extglob": "^2.1.0"
@@ -6174,7 +6284,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -6182,7 +6292,7 @@
         },
         "micromatch": {
           "version": "2.3.11",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/micromatch/-/micromatch-2.3.11.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/micromatch/-/micromatch-2.3.11.tgz",
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "requires": {
             "arr-diff": "^2.0.0",
@@ -6202,12 +6312,12 @@
           "dependencies": {
             "is-extglob": {
               "version": "1.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
               "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
             },
             "is-glob": {
               "version": "2.0.1",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "requires": {
                 "is-extglob": "^1.0.0"
@@ -6217,7 +6327,7 @@
         },
         "normalize-path": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-path/-/normalize-path-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "requires": {
             "remove-trailing-separator": "^1.0.1"
@@ -6227,7 +6337,7 @@
     },
     "http-server": {
       "version": "0.12.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-server/-/http-server-0.12.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/http-server/-/http-server-0.12.3.tgz",
       "integrity": "sha1-ugRx0OzEJYhmFss1xPryeRQKDTc=",
       "requires": {
         "basic-auth": "^1.0.3",
@@ -6244,7 +6354,7 @@
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -6253,43 +6363,28 @@
       }
     },
     "https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha1-4qkFQqu2inYuCghQ9sntrf2FBrI=",
+      "version": "4.0.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+      "integrity": "sha1-cCtx+1UgoTKmbeH2dUHZ5iFU2Cs=",
       "requires": {
-        "agent-base": "6",
+        "agent-base": "5",
         "debug": "4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
-        }
       }
     },
     "human-signals": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/human-signals/-/human-signals-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha1-xbHNFPUK6uCatsWf5jujOV/k36M="
     },
     "iban": {
       "version": "0.0.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/iban/-/iban-0.0.8.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/iban/-/iban-0.0.8.tgz",
       "integrity": "sha1-TyPSOtUEoxmjqfduyQkHu0E8rhg="
     },
     "icon-font-generator": {
-      "version": "2.1.10",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/icon-font-generator/-/icon-font-generator-2.1.10.tgz",
-      "integrity": "sha1-ldbX88RNxopfvDey4alRFIc4fro=",
+      "version": "2.1.11",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/icon-font-generator/-/icon-font-generator-2.1.11.tgz",
+      "integrity": "sha1-yFDGZEP5PsMuJI4YbAg6gzfDrnk=",
       "requires": {
         "colors": "^1.2.1",
         "glob": "^7.1.2",
@@ -6299,7 +6394,7 @@
     },
     "iconv-lite": {
       "version": "0.4.24",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -6307,22 +6402,22 @@
     },
     "ieee754": {
       "version": "1.1.13",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ieee754/-/ieee754-1.1.13.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ieee754/-/ieee754-1.1.13.tgz",
       "integrity": "sha1-7BaFWOlaoYH9h9N/VcMrvLZwi4Q="
     },
     "ignore": {
       "version": "5.1.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ignore/-/ignore-5.1.8.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ignore/-/ignore-5.1.8.tgz",
       "integrity": "sha1-8VCotQo0KJsz4i9YiavU2AFvDlc="
     },
     "immediate": {
       "version": "3.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/immediate/-/immediate-3.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
     "import-fresh": {
       "version": "3.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/import-fresh/-/import-fresh-3.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/import-fresh/-/import-fresh-3.2.1.tgz",
       "integrity": "sha1-Yz/2GFBueTr1rJG/SLcmd+FcvmY=",
       "requires": {
         "parent-module": "^1.0.0",
@@ -6331,32 +6426,32 @@
     },
     "import-lazy": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/import-lazy/-/import-lazy-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/import-lazy/-/import-lazy-2.1.0.tgz",
       "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "indent": {
       "version": "0.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/indent/-/indent-0.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/indent/-/indent-0.0.2.tgz",
       "integrity": "sha1-jHnwgBkFWbaHA0uEx676l9WpEdk="
     },
     "indent-string": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/indent-string/-/indent-string-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE="
     },
     "indexof": {
       "version": "0.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/indexof/-/indexof-0.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/indexof/-/indexof-0.0.1.tgz",
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
         "once": "^1.3.0",
@@ -6365,17 +6460,17 @@
     },
     "inherits": {
       "version": "2.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inherits/-/inherits-2.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
     },
     "ini": {
       "version": "1.3.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ini/-/ini-1.3.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ini/-/ini-1.3.5.tgz",
       "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc="
     },
     "inquirer": {
       "version": "7.3.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inquirer/-/inquirer-7.3.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/inquirer/-/inquirer-7.3.3.tgz",
       "integrity": "sha1-BNF2sq8Er8FXqD/XwQDpjuCq0AM=",
       "requires": {
         "ansi-escapes": "^4.2.1",
@@ -6395,22 +6490,22 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U="
         },
         "emoji-regex": {
           "version": "8.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
           "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc="
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0="
         },
         "string-width": {
           "version": "4.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
           "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -6420,7 +6515,7 @@
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
           "requires": {
             "ansi-regex": "^5.0.0"
@@ -6430,7 +6525,7 @@
     },
     "inquirer-autosubmit-prompt": {
       "version": "0.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inquirer-autosubmit-prompt/-/inquirer-autosubmit-prompt-0.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/inquirer-autosubmit-prompt/-/inquirer-autosubmit-prompt-0.2.0.tgz",
       "integrity": "sha1-oQ+VKvT3usnEMBDj6eCJHX6NFaE=",
       "requires": {
         "chalk": "^2.4.1",
@@ -6440,17 +6535,17 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "3.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
           "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s="
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -6460,7 +6555,7 @@
         },
         "cli-cursor": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "requires": {
             "restore-cursor": "^2.0.0"
@@ -6468,12 +6563,12 @@
         },
         "cli-width": {
           "version": "2.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-width/-/cli-width-2.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cli-width/-/cli-width-2.2.1.tgz",
           "integrity": "sha1-sEM9C06chH7xiGik7xb9X8gnHEg="
         },
         "figures": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/figures/-/figures-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/figures/-/figures-2.0.0.tgz",
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
           "requires": {
             "escape-string-regexp": "^1.0.5"
@@ -6481,7 +6576,7 @@
         },
         "inquirer": {
           "version": "6.5.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inquirer/-/inquirer-6.5.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/inquirer/-/inquirer-6.5.2.tgz",
           "integrity": "sha1-rVCUI3XQNtMn/1KMCL1fqwiZKMo=",
           "requires": {
             "ansi-escapes": "^3.2.0",
@@ -6501,22 +6596,22 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
           "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI="
         },
         "mute-stream": {
           "version": "0.0.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mute-stream/-/mute-stream-0.0.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mute-stream/-/mute-stream-0.0.7.tgz",
           "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
         },
         "onetime": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/onetime/-/onetime-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/onetime/-/onetime-2.0.1.tgz",
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "requires": {
             "mimic-fn": "^1.0.0"
@@ -6524,7 +6619,7 @@
         },
         "restore-cursor": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "requires": {
             "onetime": "^2.0.0",
@@ -6533,7 +6628,7 @@
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -6542,7 +6637,7 @@
           "dependencies": {
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -6552,7 +6647,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -6560,7 +6655,7 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
               "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
             }
           }
@@ -6569,12 +6664,12 @@
     },
     "intersection-observer": {
       "version": "0.5.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/intersection-observer/-/intersection-observer-0.5.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/intersection-observer/-/intersection-observer-0.5.1.tgz",
       "integrity": "sha1-40D8Vs50KQ/isjlNHOiMQ1Osbfo="
     },
     "invariant": {
       "version": "2.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/invariant/-/invariant-2.2.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
       "requires": {
         "loose-envify": "^1.0.0"
@@ -6582,30 +6677,25 @@
     },
     "ip-regex": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ip-regex/-/ip-regex-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ip-regex/-/ip-regex-2.1.0.tgz",
       "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
     },
     "ipaddr.js": {
       "version": "1.9.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha1-v/OFQ+64mEglB5/zoqjmy9RngbM="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
         "kind-of": "^3.0.2"
       },
       "dependencies": {
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
-        },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -6615,56 +6705,59 @@
     },
     "is-arguments": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-arguments/-/is-arguments-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-arguments/-/is-arguments-1.0.4.tgz",
       "integrity": "sha1-P6+WbHy6D/Q3+zH2JQCC/PBEjPM="
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-binary-path": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
       "requires": {
         "binary-extensions": "^2.0.0"
       }
     },
     "is-buffer": {
-      "version": "2.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-2.0.4.tgz",
-      "integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM="
+      "version": "1.1.6",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
     },
     "is-callable": {
-      "version": "1.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-callable/-/is-callable-1.2.1.tgz",
-      "integrity": "sha1-TR4hpPQ3UJ0lzlX4GENQdxQhyW0="
+      "version": "1.2.2",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-callable/-/is-callable-1.2.2.tgz",
+      "integrity": "sha1-x8ZxXNItTdtI0+GZcCI6zquwgNk="
     },
     "is-ci": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-ci/-/is-ci-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-ci/-/is-ci-2.0.0.tgz",
       "integrity": "sha1-a8YzQYGBDgS1wis9WJ/cpVAmQEw=",
       "requires": {
         "ci-info": "^2.0.0"
       }
     },
+    "is-core-module": {
+      "version": "2.0.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-core-module/-/is-core-module-2.0.0.tgz",
+      "integrity": "sha1-WFMbcK7R23wOjU6xoKLR3dZL0S0=",
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
         "kind-of": "^3.0.2"
       },
       "dependencies": {
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
-        },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -6674,12 +6767,12 @@
     },
     "is-date-object": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-date-object/-/is-date-object-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-date-object/-/is-date-object-1.0.2.tgz",
       "integrity": "sha1-vac28s2P0G0yhE53Q7+nSUw7/X4="
     },
     "is-descriptor": {
       "version": "0.1.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
       "requires": {
         "is-accessor-descriptor": "^0.1.6",
@@ -6689,24 +6782,24 @@
       "dependencies": {
         "kind-of": {
           "version": "5.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-5.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-5.1.0.tgz",
           "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0="
         }
       }
     },
     "is-docker": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-docker/-/is-docker-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-docker/-/is-docker-2.1.1.tgz",
       "integrity": "sha1-QSWojkTkUNOE4JBH7eca3C0UQVY="
     },
     "is-dotfile": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-dotfile/-/is-dotfile-1.0.3.tgz",
       "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
     },
     "is-equal-shallow": {
       "version": "0.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "requires": {
         "is-primitive": "^2.0.0"
@@ -6714,22 +6807,22 @@
     },
     "is-extendable": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extendable/-/is-extendable-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-finite": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-finite/-/is-finite-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-finite/-/is-finite-1.1.0.tgz",
       "integrity": "sha1-kEE1x3+0LAZB1qobzbxNqo2ggvM="
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
         "number-is-nan": "^1.0.0"
@@ -6737,12 +6830,12 @@
     },
     "is-generator-function": {
       "version": "1.0.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-generator-function/-/is-generator-function-1.0.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-generator-function/-/is-generator-function-1.0.7.tgz",
       "integrity": "sha1-0hMuUpuwAAp/gHlNS99c1eWBNSI="
     },
     "is-glob": {
       "version": "4.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-4.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
       "requires": {
         "is-extglob": "^2.1.1"
@@ -6750,36 +6843,36 @@
     },
     "is-installed-globally": {
       "version": "0.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
       "integrity": "sha1-/T76ee5nDRGHIzGC1bCh3QAxMUE=",
       "requires": {
         "global-dirs": "^2.0.1",
         "is-path-inside": "^3.0.1"
       }
     },
-    "is-map": {
-      "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-map/-/is-map-2.0.1.tgz",
-      "integrity": "sha1-Ug2vxDB7uOvDO4E95c58lADWRKE="
+    "is-negative-zero": {
+      "version": "2.0.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+      "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE="
     },
     "is-npm": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-npm/-/is-npm-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-npm/-/is-npm-4.0.0.tgz",
       "integrity": "sha1-yQ3YOAaW34enptgjwg0LErvjyE0="
     },
     "is-number": {
       "version": "7.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-number/-/is-number-7.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss="
     },
     "is-obj": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-obj/-/is-obj-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-obj/-/is-obj-2.0.0.tgz",
       "integrity": "sha1-Rz+wXZc3BeP9liBUUBjKjiLvSYI="
     },
     "is-observable": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-observable/-/is-observable-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-observable/-/is-observable-1.1.0.tgz",
       "integrity": "sha1-s+mGyPRN6VCGfKtUA/WjRlAFl14=",
       "requires": {
         "symbol-observable": "^1.1.0"
@@ -6787,12 +6880,12 @@
     },
     "is-path-cwd": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
       "integrity": "sha1-Z9Q7gmZKe1GR/ZEZEn6zAASKn9s="
     },
     "is-path-in-cwd": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
       "integrity": "sha1-v+Lcomxp85cmWkAJljYCk1oFOss=",
       "requires": {
         "is-path-inside": "^2.1.0"
@@ -6800,7 +6893,7 @@
       "dependencies": {
         "is-path-inside": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-path-inside/-/is-path-inside-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-path-inside/-/is-path-inside-2.1.0.tgz",
           "integrity": "sha1-fJgQWH1lmkDSe8201WFuqwWUlLI=",
           "requires": {
             "path-is-inside": "^1.0.2"
@@ -6810,17 +6903,17 @@
     },
     "is-path-inside": {
       "version": "3.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-path-inside/-/is-path-inside-3.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-path-inside/-/is-path-inside-3.0.2.tgz",
       "integrity": "sha1-9SIPyCo+IzdXKR3dycWHfyofMBc="
     },
     "is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-plain-object": {
       "version": "2.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "requires": {
         "isobject": "^3.0.1"
@@ -6828,32 +6921,32 @@
     },
     "is-posix-bracket": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
       "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
     },
     "is-potential-custom-element-name": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
       "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c="
     },
     "is-primitive": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-primitive/-/is-primitive-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
     },
     "is-promise": {
       "version": "2.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-promise/-/is-promise-2.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha1-OauVnMv5p3TPB597QMeib3YxNfE="
     },
     "is-redirect": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-redirect/-/is-redirect-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
     },
     "is-regex": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-regex/-/is-regex-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-regex/-/is-regex-1.1.1.tgz",
       "integrity": "sha1-xvmKrMVG9s7FRooHt7FTq1ZKV7k=",
       "requires": {
         "has-symbols": "^1.0.1"
@@ -6861,40 +6954,35 @@
     },
     "is-retry-allowed": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
       "integrity": "sha1-13hIi9CkZmo76KFIK58rqv7eqLQ="
+    },
+    "is-running": {
+      "version": "2.1.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-running/-/is-running-2.1.0.tgz",
+      "integrity": "sha1-MKc/9cw4VOT8JUkICen1q/jeCeA="
     },
     "is-scoped": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-scoped/-/is-scoped-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-scoped/-/is-scoped-2.1.0.tgz",
       "integrity": "sha1-/vBxN3Jli99b7kGGCCZ92ubTVm0=",
       "requires": {
         "scoped-regex": "^2.0.0"
       }
     },
-    "is-set": {
-      "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-set/-/is-set-2.0.1.tgz",
-      "integrity": "sha1-0WBK/asXJJhtMAkVdfVJRdp+X0M="
-    },
     "is-stream": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-stream/-/is-stream-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "is-string": {
-      "version": "1.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-string/-/is-string-1.0.5.tgz",
-      "integrity": "sha1-QEk+0ZjvP/R3uMf5L2ROyCpc06Y="
     },
     "is-subset": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-subset/-/is-subset-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-subset/-/is-subset-0.1.1.tgz",
       "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY="
     },
     "is-symbol": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-symbol/-/is-symbol-1.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha1-OOEBS55jKb4N6dJKQU/XRB7GGTc=",
       "requires": {
         "has-symbols": "^1.0.1"
@@ -6902,7 +6990,7 @@
     },
     "is-typed-array": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-typed-array/-/is-typed-array-1.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-typed-array/-/is-typed-array-1.1.3.tgz",
       "integrity": "sha1-pP9aXmcuGlX5nH9U5ZWXr1wd8E0=",
       "requires": {
         "available-typed-arrays": "^1.0.0",
@@ -6913,47 +7001,47 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-url": {
       "version": "1.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-url/-/is-url-1.2.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-url/-/is-url-1.2.4.tgz",
       "integrity": "sha1-BKTfRtKMTP89c9Af8Gq+sxihqlI="
     },
     "is-url-superb": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-url-superb/-/is-url-superb-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-url-superb/-/is-url-superb-4.0.0.tgz",
       "integrity": "sha1-tU0dJJm7FnknSKyWeqPstBozqMI="
     },
     "is-utf8": {
       "version": "0.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-utf8/-/is-utf8-0.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "is-valid-glob": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
       "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4="
     },
     "is-windows": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-windows/-/is-windows-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0="
     },
     "is-wsl": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-wsl/-/is-wsl-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
     },
     "is-yarn-global": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
       "integrity": "sha1-1QLTOCWQ6jAEiTdGdUyJE5lz4jI="
     },
     "is2": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is2/-/is2-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is2/-/is2-2.0.1.tgz",
       "integrity": "sha1-isNVZEhAkhzkNdlPBdOpRjTTSBo=",
       "requires": {
         "deep-is": "^0.1.3",
@@ -6963,51 +7051,37 @@
     },
     "isarray": {
       "version": "0.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-0.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isobject/-/isobject-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "issue-regex": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/issue-regex/-/issue-regex-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/issue-regex/-/issue-regex-3.1.0.tgz",
       "integrity": "sha1-BnHwlNZEnFtxL6w8lWKuy3J9cJ4="
-    },
-    "iterate-iterator": {
-      "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/iterate-iterator/-/iterate-iterator-1.0.1.tgz",
-      "integrity": "sha1-FpOnaMHd15yWkFFFlFPwgv6C6fY="
-    },
-    "iterate-value": {
-      "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/iterate-value/-/iterate-value-1.0.2.tgz",
-      "integrity": "sha1-k1EVvTfQBqUgRlNevI0H6ckzf1c=",
-      "requires": {
-        "es-get-iterator": "^1.0.2",
-        "iterate-iterator": "^1.0.1"
-      }
     },
     "js-tokens": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/js-tokens/-/js-tokens-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk="
     },
     "js-yaml": {
       "version": "3.14.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/js-yaml/-/js-yaml-3.14.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/js-yaml/-/js-yaml-3.14.0.tgz",
       "integrity": "sha1-p6NBcPJqIbsWJCTYray0ETpp5II=",
       "requires": {
         "argparse": "^1.0.7",
@@ -7016,12 +7090,12 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsdom": {
       "version": "16.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsdom/-/jsdom-16.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/jsdom/-/jsdom-16.4.0.tgz",
       "integrity": "sha1-NgBb3i0Tb3Pu4agwxtReVUCO3ds=",
       "requires": {
         "abab": "^2.0.3",
@@ -7054,7 +7128,7 @@
       "dependencies": {
         "tough-cookie": {
           "version": "3.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tough-cookie/-/tough-cookie-3.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tough-cookie/-/tough-cookie-3.0.1.tgz",
           "integrity": "sha1-nfT1fnOcJpMKAYGEiH9K233Kc7I=",
           "requires": {
             "ip-regex": "^2.1.0",
@@ -7064,7 +7138,7 @@
         },
         "tr46": {
           "version": "2.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tr46/-/tr46-2.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tr46/-/tr46-2.0.2.tgz",
           "integrity": "sha1-Ayc1ht7xWVrgj+2zjXczzukdJHk=",
           "requires": {
             "punycode": "^2.1.1"
@@ -7072,13 +7146,13 @@
         },
         "webidl-conversions": {
           "version": "6.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
           "integrity": "sha1-kRG01+qArNQPUnDWZmIa+ni2lRQ="
         },
         "whatwg-url": {
-          "version": "8.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/whatwg-url/-/whatwg-url-8.2.2.tgz",
-          "integrity": "sha1-hef5eVEItT1VTOxkCy6K7ioNS/0=",
+          "version": "8.4.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/whatwg-url/-/whatwg-url-8.4.0.tgz",
+          "integrity": "sha1-UPuWFbBUaVkdKyvW367SlC7XKDc=",
           "requires": {
             "lodash.sortby": "^4.7.0",
             "tr46": "^2.0.2",
@@ -7089,60 +7163,60 @@
     },
     "jsesc": {
       "version": "2.5.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsesc/-/jsesc-2.5.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q="
     },
     "json-buffer": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-buffer/-/json-buffer-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha1-kziAKjDTtmBfvgYT4JQAjKjAWhM="
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha1-fEeAWpQxmSjgV3dAXcEuH3pO4C0="
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json3": {
       "version": "3.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json3/-/json3-3.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
     },
     "json5": {
       "version": "2.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json5/-/json5-2.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/json5/-/json5-2.1.3.tgz",
       "integrity": "sha1-ybD3+pIzv+WAf+ZvzzpWF+1ZfUM=",
       "requires": {
         "minimist": "^1.2.5"
       }
     },
     "jsonschema": {
-      "version": "1.2.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsonschema/-/jsonschema-1.2.6.tgz",
-      "integrity": "sha1-UrCo6dwGu65ylSSdA+S5+u6KDAs="
+      "version": "1.4.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/jsonschema/-/jsonschema-1.4.0.tgz",
+      "integrity": "sha1-Gvo0xLwiGQ2OQicewXrIs0BPh7I="
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "requires": {
         "assert-plus": "1.0.0",
@@ -7153,12 +7227,12 @@
     },
     "jsts": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsts/-/jsts-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/jsts/-/jsts-1.1.1.tgz",
       "integrity": "sha1-mln5rg0M5a9lC3zc3qnmE/gKDd8="
     },
     "jszip": {
       "version": "3.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jszip/-/jszip-3.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/jszip/-/jszip-3.5.0.tgz",
       "integrity": "sha1-tP0fNoJFNGZY54H+yWdYAkieFfY=",
       "requires": {
         "lie": "~3.3.0",
@@ -7169,30 +7243,30 @@
     },
     "just-extend": {
       "version": "4.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/just-extend/-/just-extend-4.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/just-extend/-/just-extend-4.1.1.tgz",
       "integrity": "sha1-FY8f2wHxKMQR3IsoantIN7NUUoI="
     },
     "keyv": {
-      "version": "4.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/keyv/-/keyv-4.0.1.tgz",
-      "integrity": "sha1-n+cDy0qU1tEXKdMgrwMzB+/QLuY=",
+      "version": "4.0.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/keyv/-/keyv-4.0.3.tgz",
+      "integrity": "sha1-TzqpjeJUgDyvzSiWc0EI2qNeQlQ=",
       "requires": {
         "json-buffer": "3.0.1"
       }
     },
     "kind-of": {
       "version": "6.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-6.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0="
     },
     "kuler": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kuler/-/kuler-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kuler/-/kuler-2.0.0.tgz",
       "integrity": "sha1-4sVwo4ADiPtEQH6FFTHB1nCwYbM="
     },
     "latest-version": {
       "version": "5.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/latest-version/-/latest-version-5.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/latest-version/-/latest-version-5.1.0.tgz",
       "integrity": "sha1-EZ3+kI/jjRXfpD7NE/oS7Igy+s4=",
       "requires": {
         "package-json": "^6.3.0"
@@ -7200,7 +7274,7 @@
     },
     "launchpad": {
       "version": "0.7.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/launchpad/-/launchpad-0.7.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/launchpad/-/launchpad-0.7.5.tgz",
       "integrity": "sha1-oWlQyTdXLxDvAcm+lFqW96745Cc=",
       "optional": true,
       "requires": {
@@ -7216,16 +7290,22 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "optional": true
+        },
         "rimraf": {
           "version": "3.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rimraf/-/rimraf-3.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/rimraf/-/rimraf-3.0.2.tgz",
           "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
           "optional": true,
           "requires": {
@@ -7236,7 +7316,7 @@
     },
     "lazystream": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lazystream/-/lazystream-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lazystream/-/lazystream-1.0.0.tgz",
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "requires": {
         "readable-stream": "^2.0.5"
@@ -7244,7 +7324,7 @@
     },
     "levn": {
       "version": "0.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/levn/-/levn-0.4.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/levn/-/levn-0.4.1.tgz",
       "integrity": "sha1-rkViwAdHO5MqYgDUAyaN0v/8at4=",
       "requires": {
         "prelude-ls": "^1.2.1",
@@ -7253,25 +7333,20 @@
     },
     "lie": {
       "version": "3.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lie/-/lie-3.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lie/-/lie-3.3.0.tgz",
       "integrity": "sha1-3Pgt7lRfRgdNryAMfBxaCOD0D2o=",
       "requires": {
         "immediate": "~3.0.5"
       }
     },
-    "lightercollective": {
-      "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lightercollective/-/lightercollective-0.3.0.tgz",
-      "integrity": "sha1-HwdjhkLsZF1wvbaasnd2dvNaKPA="
-    },
     "lines-and-columns": {
       "version": "1.1.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
     },
     "listr": {
       "version": "0.14.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/listr/-/listr-0.14.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/listr/-/listr-0.14.3.tgz",
       "integrity": "sha1-L+qQlgTkNL5GTFC926DUlpKPpYY=",
       "requires": {
         "@samverschueren/stream-to-observable": "^0.3.0",
@@ -7287,14 +7362,14 @@
       "dependencies": {
         "p-map": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-map/-/p-map-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-map/-/p-map-2.1.0.tgz",
           "integrity": "sha1-MQko/u+cnsxltosXaTAYpmXOoXU="
         }
       }
     },
     "listr-input": {
       "version": "0.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/listr-input/-/listr-input-0.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/listr-input/-/listr-input-0.2.1.tgz",
       "integrity": "sha1-znNcNFMGg1gDiP35Ri7P69O2YSY=",
       "requires": {
         "inquirer": "^7.0.0",
@@ -7305,12 +7380,12 @@
     },
     "listr-silent-renderer": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
       "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4="
     },
     "listr-update-renderer": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
       "integrity": "sha1-Tqg2hUinuK7LfgbYyVy0WuLt5qI=",
       "requires": {
         "chalk": "^1.1.3",
@@ -7325,12 +7400,12 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -7342,7 +7417,7 @@
         },
         "figures": {
           "version": "1.7.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/figures/-/figures-1.7.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/figures/-/figures-1.7.0.tgz",
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "requires": {
             "escape-string-regexp": "^1.0.5",
@@ -7351,12 +7426,12 @@
         },
         "indent-string": {
           "version": "3.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/indent-string/-/indent-string-3.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/indent-string/-/indent-string-3.2.0.tgz",
           "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
         },
         "log-symbols": {
           "version": "1.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/log-symbols/-/log-symbols-1.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/log-symbols/-/log-symbols-1.0.2.tgz",
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "requires": {
             "chalk": "^1.0.0"
@@ -7364,14 +7439,14 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
     "listr-verbose-renderer": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
       "integrity": "sha1-8RMhZ1NepMEmEQK58o2sfLoeA9s=",
       "requires": {
         "chalk": "^2.4.1",
@@ -7382,7 +7457,7 @@
       "dependencies": {
         "chalk": {
           "version": "2.4.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -7392,7 +7467,7 @@
         },
         "cli-cursor": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "requires": {
             "restore-cursor": "^2.0.0"
@@ -7400,7 +7475,7 @@
         },
         "figures": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/figures/-/figures-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/figures/-/figures-2.0.0.tgz",
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
           "requires": {
             "escape-string-regexp": "^1.0.5"
@@ -7408,12 +7483,12 @@
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
           "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI="
         },
         "onetime": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/onetime/-/onetime-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/onetime/-/onetime-2.0.1.tgz",
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "requires": {
             "mimic-fn": "^1.0.0"
@@ -7421,7 +7496,7 @@
         },
         "restore-cursor": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "requires": {
             "onetime": "^2.0.0",
@@ -7432,7 +7507,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -7444,14 +7519,14 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         }
       }
     },
     "locate-path": {
       "version": "6.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/locate-path/-/locate-path-6.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha1-VTIeswn+u8WcSAHZMackUqaB0oY=",
       "requires": {
         "p-locate": "^5.0.0"
@@ -7459,17 +7534,17 @@
     },
     "lodash": {
       "version": "4.17.20",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash/-/lodash-4.17.20.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha1-tEqbYpe8tpjxxRo1RaKzs2jVnFI="
     },
     "lodash-es": {
       "version": "4.17.15",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash-es/-/lodash-es-4.17.15.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash-es/-/lodash-es-4.17.15.tgz",
       "integrity": "sha1-Ib2Wg5NUQS8j16EDQOXqxu5FXXg="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "requires": {
         "lodash._basecopy": "^3.0.0",
@@ -7478,37 +7553,37 @@
     },
     "lodash._basecopy": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
     },
     "lodash._basecreate": {
       "version": "3.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
       "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE="
     },
     "lodash._getnative": {
       "version": "3.9.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
     "lodash.create": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.create/-/lodash.create-3.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "requires": {
         "lodash._baseassign": "^3.0.0",
@@ -7518,47 +7593,47 @@
     },
     "lodash.defaults": {
       "version": "4.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
     },
     "lodash.difference": {
       "version": "4.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.difference/-/lodash.difference-4.5.0.tgz",
       "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
     },
     "lodash.flatten": {
       "version": "4.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
     "lodash.get": {
       "version": "4.4.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.get/-/lodash.get-4.4.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.isarguments": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
     },
     "lodash.isarray": {
       "version": "3.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
     },
     "lodash.isequal": {
       "version": "4.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.keys": {
       "version": "3.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "requires": {
         "lodash._getnative": "^3.0.0",
@@ -7568,17 +7643,17 @@
     },
     "lodash.padend": {
       "version": "4.6.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.padend/-/lodash.padend-4.6.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.padend/-/lodash.padend-4.6.1.tgz",
       "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4="
     },
     "lodash.sortby": {
       "version": "4.7.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
     "lodash.template": {
       "version": "4.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.template/-/lodash.template-4.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.template/-/lodash.template-4.5.0.tgz",
       "integrity": "sha1-+XYZXPPzR9DV9SSDVp/oAxzM6Ks=",
       "requires": {
         "lodash._reinterpolate": "^3.0.0",
@@ -7587,7 +7662,7 @@
     },
     "lodash.templatesettings": {
       "version": "4.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
       "integrity": "sha1-5IExDwSdPPbUfpEq0JMTsVTw+zM=",
       "requires": {
         "lodash._reinterpolate": "^3.0.0"
@@ -7595,17 +7670,17 @@
     },
     "lodash.union": {
       "version": "4.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.union/-/lodash.union-4.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.union/-/lodash.union-4.6.0.tgz",
       "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
     },
     "lodash.zip": {
       "version": "4.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.zip/-/lodash.zip-4.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.zip/-/lodash.zip-4.2.0.tgz",
       "integrity": "sha1-7GZi5IlkCO1KtsVCo5kLcswIACA="
     },
     "log-symbols": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/log-symbols/-/log-symbols-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/log-symbols/-/log-symbols-4.0.0.tgz",
       "integrity": "sha1-abPMRtIPRI7M23XqH6cz2eghySA=",
       "requires": {
         "chalk": "^4.0.0"
@@ -7613,7 +7688,7 @@
     },
     "log-update": {
       "version": "2.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/log-update/-/log-update-2.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/log-update/-/log-update-2.3.0.tgz",
       "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
       "requires": {
         "ansi-escapes": "^3.0.0",
@@ -7623,17 +7698,17 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "3.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
           "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s="
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "cli-cursor": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "requires": {
             "restore-cursor": "^2.0.0"
@@ -7641,17 +7716,17 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
           "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI="
         },
         "onetime": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/onetime/-/onetime-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/onetime/-/onetime-2.0.1.tgz",
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "requires": {
             "mimic-fn": "^1.0.0"
@@ -7659,7 +7734,7 @@
         },
         "restore-cursor": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "requires": {
             "onetime": "^2.0.0",
@@ -7668,7 +7743,7 @@
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -7677,7 +7752,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
             "ansi-regex": "^3.0.0"
@@ -7685,7 +7760,7 @@
         },
         "wrap-ansi": {
           "version": "3.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
           "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
           "requires": {
             "string-width": "^2.1.1",
@@ -7696,7 +7771,7 @@
     },
     "logform": {
       "version": "1.10.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/logform/-/logform-1.10.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/logform/-/logform-1.10.0.tgz",
       "integrity": "sha1-ydVZhxTJK1RuI/TngUfEDx4CAS4=",
       "requires": {
         "colors": "^1.2.1",
@@ -7704,23 +7779,16 @@
         "fecha": "^2.3.3",
         "ms": "^2.1.1",
         "triple-beam": "^1.2.0"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
-        }
       }
     },
     "lolex": {
       "version": "1.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lolex/-/lolex-1.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lolex/-/lolex-1.3.2.tgz",
       "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE="
     },
     "loose-envify": {
       "version": "1.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/loose-envify/-/loose-envify-1.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -7728,7 +7796,7 @@
     },
     "loud-rejection": {
       "version": "1.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "requires": {
         "currently-unhandled": "^0.4.1",
@@ -7737,17 +7805,17 @@
     },
     "lower-case": {
       "version": "1.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lower-case/-/lower-case-1.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lower-case/-/lower-case-1.1.4.tgz",
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
     },
     "lowercase-keys": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8="
     },
     "lru-cache": {
       "version": "6.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lru-cache/-/lru-cache-6.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
       "requires": {
         "yallist": "^4.0.0"
@@ -7755,12 +7823,12 @@
     },
     "luxon": {
       "version": "1.25.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/luxon/-/luxon-1.25.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/luxon/-/luxon-1.25.0.tgz",
       "integrity": "sha1-2GIZ6QvAECwOspnWWy9ele/h/nI="
     },
     "magic-string": {
       "version": "0.22.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/magic-string/-/magic-string-0.22.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/magic-string/-/magic-string-0.22.5.tgz",
       "integrity": "sha1-jpz1r930Q4XB2lvCpqDb0QsDZX4=",
       "requires": {
         "vlq": "^0.2.2"
@@ -7768,7 +7836,7 @@
     },
     "make-dir": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/make-dir/-/make-dir-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha1-QV6WcEazp/HRhSd9hKpYIDcmoT8=",
       "requires": {
         "semver": "^6.0.0"
@@ -7776,14 +7844,14 @@
       "dependencies": {
         "semver": {
           "version": "6.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/semver/-/semver-6.3.0.tgz",
           "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0="
         }
       }
     },
     "map-age-cleaner": {
       "version": "0.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
       "integrity": "sha1-fVg6cwZDTAVf5HSw9FB45uG0uSo=",
       "requires": {
         "p-defer": "^1.0.0"
@@ -7791,22 +7859,22 @@
     },
     "map-cache": {
       "version": "0.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-cache/-/map-cache-0.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
     },
     "map-obj": {
       "version": "4.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-obj/-/map-obj-4.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/map-obj/-/map-obj-4.1.0.tgz",
       "integrity": "sha1-uRIhtUJzS58UJWwBMsiXxdclb9U="
     },
     "map-stream": {
-      "version": "0.0.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-stream/-/map-stream-0.0.7.tgz",
-      "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg="
+      "version": "0.1.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
     },
     "map-visit": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-visit/-/map-visit-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
         "object-visit": "^1.0.0"
@@ -7814,7 +7882,7 @@
     },
     "matcher": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/matcher/-/matcher-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/matcher/-/matcher-1.1.1.tgz",
       "integrity": "sha1-UdgwHhOPhAmCszixFrsMCa9iwcI=",
       "requires": {
         "escape-string-regexp": "^1.0.4"
@@ -7822,34 +7890,27 @@
     },
     "math-random": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/math-random/-/math-random-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/math-random/-/math-random-1.0.4.tgz",
       "integrity": "sha1-XdaUPJOFSCZwFtTjTwV1gwgMUUw="
     },
     "md5": {
       "version": "2.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/md5/-/md5-2.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/md5/-/md5-2.3.0.tgz",
       "integrity": "sha1-w9qaaq46MLRreww0m4exENw72k8=",
       "requires": {
         "charenc": "0.0.2",
         "crypt": "0.0.2",
         "is-buffer": "~1.1.6"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
-        }
       }
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
       "version": "4.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mem/-/mem-4.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mem/-/mem-4.3.0.tgz",
       "integrity": "sha1-Rhr0l7xK4JYIzbLmDu+2m/90QXg=",
       "requires": {
         "map-age-cleaner": "^0.1.1",
@@ -7859,7 +7920,7 @@
     },
     "meow": {
       "version": "6.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/meow/-/meow-6.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/meow/-/meow-6.1.1.tgz",
       "integrity": "sha1-GtZMS3ayok37L2Nf3crfMg0lFGc=",
       "requires": {
         "@types/minimist": "^1.2.0",
@@ -7877,12 +7938,12 @@
       "dependencies": {
         "type-fest": {
           "version": "0.13.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.13.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.13.1.tgz",
           "integrity": "sha1-AXLLW86AsL1ULqNI21DH4hg02TQ="
         },
         "yargs-parser": {
           "version": "18.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-18.1.3.tgz",
           "integrity": "sha1-vmjEl1xrKr9GkjawyHA2L6sJp7A=",
           "requires": {
             "camelcase": "^5.0.0",
@@ -7893,37 +7954,37 @@
     },
     "merge-descriptors": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "merge-stream": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/merge-stream/-/merge-stream-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A="
     },
     "merge2": {
       "version": "1.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/merge2/-/merge2-1.4.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4="
     },
     "methods": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/methods/-/methods-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "mgrs": {
       "version": "0.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mgrs/-/mgrs-0.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mgrs/-/mgrs-0.0.0.tgz",
       "integrity": "sha1-qqK0gpMXv4ERipYNMlbgbdlnS40="
     },
     "microbuffer": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/microbuffer/-/microbuffer-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/microbuffer/-/microbuffer-1.0.0.tgz",
       "integrity": "sha1-izgy7UDIfVH0e7I0kTppinVtGdI="
     },
     "micromatch": {
       "version": "4.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/micromatch/-/micromatch-4.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/micromatch/-/micromatch-4.0.2.tgz",
       "integrity": "sha1-T8sJmb+fvC/L3SEvbWKbmlbDklk=",
       "requires": {
         "braces": "^3.0.1",
@@ -7932,17 +7993,17 @@
     },
     "mime": {
       "version": "1.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mime/-/mime-1.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mime/-/mime-1.6.0.tgz",
       "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE="
     },
     "mime-db": {
       "version": "1.44.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mime-db/-/mime-db-1.44.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mime-db/-/mime-db-1.44.0.tgz",
       "integrity": "sha1-+hHF6wrKEzS0Izy01S8QxaYnL5I="
     },
     "mime-types": {
       "version": "2.1.27",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mime-types/-/mime-types-2.1.27.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mime-types/-/mime-types-2.1.27.tgz",
       "integrity": "sha1-R5SfmOJ56lMRn1ci4PNOUpvsAJ8=",
       "requires": {
         "mime-db": "1.44.0"
@@ -7950,66 +8011,41 @@
     },
     "mimic-fn": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs="
     },
     "mimic-response": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mimic-response/-/mimic-response-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mimic-response/-/mimic-response-2.1.0.tgz",
       "integrity": "sha1-0Tdj019hPQnsN+uzC6wEacDuj0M="
     },
     "min-indent": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/min-indent/-/min-indent-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha1-pj9oFnOzBXH76LwlaGrnRu76mGk="
     },
     "minify": {
-      "version": "5.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minify/-/minify-5.1.1.tgz",
-      "integrity": "sha1-azYTYYWdOlYv9qCXrgZMILzLW0A=",
+      "version": "5.2.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minify/-/minify-5.2.0.tgz",
+      "integrity": "sha1-5MhxZDgNRDdp0YoGhthc4ktQA18=",
       "requires": {
         "clean-css": "^4.1.6",
         "css-b64-images": "~0.2.5",
         "debug": "^4.1.0",
         "html-minifier": "^4.0.0",
-        "terser": "^4.0.0",
+        "terser": "^5.3.2",
         "try-catch": "^3.0.0",
         "try-to-catch": "^3.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
-        },
-        "terser": {
-          "version": "4.8.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/terser/-/terser-4.8.0.tgz",
-          "integrity": "sha1-YwVjQ9fHC7KfOvZlhlpG/gOg3xc=",
-          "requires": {
-            "commander": "^2.20.0",
-            "source-map": "~0.6.1",
-            "source-map-support": "~0.5.12"
-          }
-        }
       }
     },
     "minimalistic-assert": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc="
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimatch/-/minimatch-3.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -8017,7 +8053,7 @@
     },
     "minimatch-all": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimatch-all/-/minimatch-all-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minimatch-all/-/minimatch-all-1.1.0.tgz",
       "integrity": "sha1-QMSWonouEo0Zv3WOdrsBoMcUV4c=",
       "requires": {
         "minimatch": "^3.0.2"
@@ -8025,12 +8061,12 @@
     },
     "minimist": {
       "version": "1.2.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimist/-/minimist-1.2.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI="
     },
     "minimist-options": {
       "version": "4.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimist-options/-/minimist-options-4.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minimist-options/-/minimist-options-4.1.0.tgz",
       "integrity": "sha1-wGVXE8U6ii69d/+iR9NCxA8BBhk=",
       "requires": {
         "arrify": "^1.0.1",
@@ -8040,7 +8076,7 @@
     },
     "minipass": {
       "version": "3.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minipass/-/minipass-3.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minipass/-/minipass-3.1.3.tgz",
       "integrity": "sha1-fUL/HzljVILhX5zbUxhN7r1YFf0=",
       "requires": {
         "yallist": "^4.0.0"
@@ -8048,7 +8084,7 @@
     },
     "minizlib": {
       "version": "2.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minizlib/-/minizlib-2.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha1-6Q00Zrogm5MkUVCKEc49NjIUWTE=",
       "requires": {
         "minipass": "^3.0.0",
@@ -8057,7 +8093,7 @@
     },
     "mixin-deep": {
       "version": "1.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mixin-deep/-/mixin-deep-1.3.2.tgz",
       "integrity": "sha1-ESC0PcNZp4Xc5ltVuC4lfM9HlWY=",
       "requires": {
         "for-in": "^1.0.2",
@@ -8066,7 +8102,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extendable/-/is-extendable-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "requires": {
             "is-plain-object": "^2.0.4"
@@ -8076,21 +8112,22 @@
     },
     "mkdirp": {
       "version": "0.5.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mkdirp/-/mkdirp-0.5.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
       "requires": {
         "minimist": "^1.2.5"
       }
     },
     "mocha": {
-      "version": "8.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mocha/-/mocha-8.1.3.tgz",
-      "integrity": "sha1-XpP4c+Nd/daWF+p1+caMLKYcKsU=",
+      "version": "8.2.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mocha/-/mocha-8.2.0.tgz",
+      "integrity": "sha1-+Kp5EQtLWmWAxl1N2Ag8QlKCYk4=",
       "requires": {
+        "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "chokidar": "3.4.2",
-        "debug": "4.1.1",
+        "chokidar": "3.4.3",
+        "debug": "4.2.0",
         "diff": "4.0.2",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
@@ -8101,64 +8138,50 @@
         "log-symbols": "4.0.0",
         "minimatch": "3.0.4",
         "ms": "2.1.2",
-        "object.assign": "4.1.0",
-        "promise.allsettled": "1.0.2",
-        "serialize-javascript": "4.0.0",
-        "strip-json-comments": "3.0.1",
-        "supports-color": "7.1.0",
+        "nanoid": "3.1.12",
+        "serialize-javascript": "5.0.1",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "7.2.0",
         "which": "2.0.2",
         "wide-align": "1.1.3",
-        "workerpool": "6.0.0",
+        "workerpool": "6.0.2",
         "yargs": "13.3.2",
         "yargs-parser": "13.1.2",
-        "yargs-unparser": "1.6.1"
+        "yargs-unparser": "2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-          "requires": {
-            "ms": "^2.1.1"
-          }
         },
         "escape-string-regexp": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
           "integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ="
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/locate-path/-/locate-path-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/locate-path/-/locate-path-3.0.0.tgz",
           "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "requires": {
             "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
           }
         },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
-        },
         "p-limit": {
           "version": "2.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-limit/-/p-limit-2.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-limit/-/p-limit-2.3.0.tgz",
           "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
           "requires": {
             "p-try": "^2.0.0"
@@ -8166,7 +8189,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-locate/-/p-locate-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-locate/-/p-locate-3.0.0.tgz",
           "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "requires": {
             "p-limit": "^2.0.0"
@@ -8174,12 +8197,12 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-exists/-/path-exists-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "requires": {
             "emoji-regex": "^7.0.1",
@@ -8189,28 +8212,23 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "requires": {
             "ansi-regex": "^4.1.0"
           }
         },
-        "strip-json-comments": {
-          "version": "3.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-          "integrity": "sha1-hXE5dakfuHvxswXMp3OV5A0qZKc="
-        },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=",
+          "version": "7.2.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "requires": {
             "has-flag": "^4.0.0"
           }
         },
         "which": {
           "version": "2.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/which/-/which-2.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/which/-/which-2.0.2.tgz",
           "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
           "requires": {
             "isexe": "^2.0.0"
@@ -8218,7 +8236,7 @@
         },
         "yargs": {
           "version": "13.3.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs/-/yargs-13.3.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs/-/yargs-13.3.2.tgz",
           "integrity": "sha1-rX/+/sGqWVZayRX4Lcyzipwxot0=",
           "requires": {
             "cliui": "^5.0.0",
@@ -8235,7 +8253,7 @@
           "dependencies": {
             "find-up": {
               "version": "3.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-up/-/find-up-3.0.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/find-up/-/find-up-3.0.0.tgz",
               "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
               "requires": {
                 "locate-path": "^3.0.0"
@@ -8245,24 +8263,88 @@
         }
       }
     },
+    "mocha-junit-reporter": {
+      "version": "2.0.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mocha-junit-reporter/-/mocha-junit-reporter-2.0.0.tgz",
+      "integrity": "sha1-O/mQ/OekLA0rcY8YhVOiXZ8kuaI=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.2.0",
+        "md5": "^2.1.0",
+        "mkdirp": "~0.5.1",
+        "strip-ansi": "^4.0.0",
+        "xml": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "mocha-multi-reporters": {
+      "version": "1.1.7",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mocha-multi-reporters/-/mocha-multi-reporters-1.1.7.tgz",
+      "integrity": "sha1-zH8/TTL0eFIJQdhSq7ZNmYhYfYI=",
+      "requires": {
+        "debug": "^3.1.0",
+        "lodash": "^4.16.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "moment": {
-      "version": "2.29.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/moment/-/moment-2.29.0.tgz",
-      "integrity": "sha1-/L75VYRNkd61VDhhPdzsVuhqNCU="
+      "version": "2.29.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha1-sr52n6MZQL6e7qZGnAdeNQBvo9M="
     },
     "mout": {
       "version": "1.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mout/-/mout-1.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mout/-/mout-1.2.2.tgz",
       "integrity": "sha1-ybcYpJmAagYyzt4XjoD0NiWed30="
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "version": "2.1.2",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
     },
     "multer": {
       "version": "1.4.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/multer/-/multer-1.4.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/multer/-/multer-1.4.2.tgz",
       "integrity": "sha1-Lx9NEtuu66dMs35iPyNL9NPSBXo=",
       "requires": {
         "append-field": "^1.0.0",
@@ -8277,12 +8359,12 @@
     },
     "multi-clamp": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/multi-clamp/-/multi-clamp-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/multi-clamp/-/multi-clamp-1.1.0.tgz",
       "integrity": "sha1-nQeOMJYXSi+5CGp7fPGdFcNBWGI="
     },
     "multipipe": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/multipipe/-/multipipe-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/multipipe/-/multipipe-1.0.2.tgz",
       "integrity": "sha1-zBPv2DPJzamfIk+GhGG44aP9k50=",
       "requires": {
         "duplexer2": "^0.1.2",
@@ -8291,12 +8373,12 @@
     },
     "mute-stream": {
       "version": "0.0.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mute-stream/-/mute-stream-0.0.8.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha1-FjDEKyJR/4HiooPelqVJfqkuXg0="
     },
     "mz": {
       "version": "2.7.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mz/-/mz-2.7.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mz/-/mz-2.7.0.tgz",
       "integrity": "sha1-lQCAV6Vsr63CvGPd5/n/aVWUjjI=",
       "requires": {
         "any-promise": "^1.0.0",
@@ -8305,13 +8387,18 @@
       }
     },
     "nan": {
-      "version": "2.14.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha1-174036MQW5FJTDFHCJMV7/iHSwE="
+      "version": "2.14.2",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha1-9TdkAGlRaPTMaUrJOT0MlYXu6hk="
+    },
+    "nanoid": {
+      "version": "3.1.12",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/nanoid/-/nanoid-3.1.12.tgz",
+      "integrity": "sha1-b3c2xi6NOUIWAeSgx3YjqX6mllQ="
     },
     "nanomatch": {
       "version": "1.2.13",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nanomatch/-/nanomatch-1.2.13.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/nanomatch/-/nanomatch-1.2.13.tgz",
       "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
       "requires": {
         "arr-diff": "^4.0.0",
@@ -8329,17 +8416,17 @@
     },
     "native-promise-only": {
       "version": "0.8.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/native-promise-only/-/native-promise-only-0.8.1.tgz",
       "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
     "neatequal": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/neatequal/-/neatequal-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/neatequal/-/neatequal-1.0.0.tgz",
       "integrity": "sha1-LuEhG8n6bkxVcV/SELsFYC6xrjs=",
       "requires": {
         "varstream": "^0.3.2"
@@ -8347,17 +8434,17 @@
     },
     "negotiator": {
       "version": "0.6.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/negotiator/-/negotiator-0.6.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha1-/qz3zPUlp3rpY0Q2pkiD/+yjRvs="
     },
     "neo-async": {
       "version": "2.6.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/neo-async/-/neo-async-2.6.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8="
     },
     "new-github-release-url": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/new-github-release-url/-/new-github-release-url-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/new-github-release-url/-/new-github-release-url-1.0.0.tgz",
       "integrity": "sha1-SThH5v7M45wkfp2Jkpvnc9Ln93c=",
       "requires": {
         "type-fest": "^0.4.1"
@@ -8365,20 +8452,14 @@
       "dependencies": {
         "type-fest": {
           "version": "0.4.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.4.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.4.1.tgz",
           "integrity": "sha1-i993dDOF2KTxO6lfYQ9czWjHKPg="
         }
       }
     },
-    "nice-try": {
-      "version": "1.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
-      "optional": true
-    },
     "nise": {
       "version": "4.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nise/-/nise-4.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/nise/-/nise-4.0.4.tgz",
       "integrity": "sha1-1z3qPlcx5lYZkrj1cL6eNjxFEt0=",
       "requires": {
         "@sinonjs/commons": "^1.7.0",
@@ -8390,7 +8471,7 @@
       "dependencies": {
         "path-to-regexp": {
           "version": "1.8.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
           "integrity": "sha1-iHs7qdhDk+h6CgufTLdWGYtTVIo=",
           "requires": {
             "isarray": "0.0.1"
@@ -8400,7 +8481,7 @@
     },
     "no-case": {
       "version": "2.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/no-case/-/no-case-2.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/no-case/-/no-case-2.3.2.tgz",
       "integrity": "sha1-YLgTOWvjmz8SiKTB7V0efSi0ZKw=",
       "requires": {
         "lower-case": "^1.1.1"
@@ -8408,7 +8489,7 @@
     },
     "node-gyp": {
       "version": "3.8.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/node-gyp/-/node-gyp-3.8.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/node-gyp/-/node-gyp-3.8.0.tgz",
       "integrity": "sha1-VAMEJhwzDoDQ1e3OJTpoyzlkIYw=",
       "requires": {
         "fstream": "^1.0.0",
@@ -8427,12 +8508,12 @@
     },
     "node-status-codes": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/node-status-codes/-/node-status-codes-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/node-status-codes/-/node-status-codes-1.0.0.tgz",
       "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
     },
     "nomnom": {
       "version": "1.8.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nomnom/-/nomnom-1.8.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/nomnom/-/nomnom-1.8.1.tgz",
       "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
       "requires": {
         "chalk": "~0.4.0",
@@ -8441,12 +8522,12 @@
       "dependencies": {
         "ansi-styles": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-1.0.0.tgz",
           "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
         },
         "chalk": {
           "version": "0.4.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-0.4.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-0.4.0.tgz",
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "requires": {
             "ansi-styles": "~1.0.0",
@@ -8456,19 +8537,19 @@
         },
         "strip-ansi": {
           "version": "0.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-0.1.1.tgz",
           "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
         },
         "underscore": {
           "version": "1.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/underscore/-/underscore-1.6.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/underscore/-/underscore-1.6.0.tgz",
           "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
         }
       }
     },
     "noms": {
       "version": "0.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/noms/-/noms-0.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/noms/-/noms-0.0.0.tgz",
       "integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
       "dev": true,
       "requires": {
@@ -8478,7 +8559,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
@@ -8492,7 +8573,7 @@
     },
     "nopt": {
       "version": "3.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nopt/-/nopt-3.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "requires": {
         "abbrev": "1"
@@ -8500,7 +8581,7 @@
     },
     "normalize-package-data": {
       "version": "2.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
       "requires": {
         "hosted-git-info": "^2.1.4",
@@ -8511,24 +8592,24 @@
       "dependencies": {
         "hosted-git-info": {
           "version": "2.8.8",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
           "integrity": "sha1-dTm9S8Hg4KiVgVouAmJCCxKFhIg="
         }
       }
     },
     "normalize-path": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-path/-/normalize-path-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU="
     },
     "normalize-url": {
       "version": "4.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-url/-/normalize-url-4.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/normalize-url/-/normalize-url-4.5.0.tgz",
       "integrity": "sha1-RTNUCH5sqWlXvY9br3U/WYIUISk="
     },
     "np": {
       "version": "6.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/np/-/np-6.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/np/-/np-6.5.0.tgz",
       "integrity": "sha1-EJLgAafdIkErtFnZvLhqQ4BmYPI=",
       "requires": {
         "@samverschueren/stream-to-observable": "^0.3.0",
@@ -8569,17 +8650,16 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha1-kK51xCTQCNJiTFvynq0xd+v881k=",
+          "version": "4.3.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
         "array-union": {
           "version": "1.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-union/-/array-union-1.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-union/-/array-union-1.0.2.tgz",
           "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
           "requires": {
             "array-uniq": "^1.0.1"
@@ -8587,7 +8667,7 @@
         },
         "chalk": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-3.0.0.tgz",
           "integrity": "sha1-P3PCv1JlkfV0zEksUeJFY0n4ROQ=",
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -8596,7 +8676,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "requires": {
             "color-name": "~1.1.4"
@@ -8604,12 +8684,12 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
         },
         "del": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/del/-/del-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/del/-/del-4.1.1.tgz",
           "integrity": "sha1-no8RciLqRKMf86FWwEm5kFKp8LQ=",
           "requires": {
             "@types/glob": "^7.1.1",
@@ -8623,12 +8703,12 @@
         },
         "escape-string-regexp": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
           "integrity": "sha1-owME6Z2qMuI7L9IPUbq9B8/8o0Q="
         },
         "globby": {
           "version": "6.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/globby/-/globby-6.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "requires": {
             "array-union": "^1.0.1",
@@ -8640,19 +8720,19 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pify/-/pify-2.3.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
             }
           }
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
         },
         "log-symbols": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/log-symbols/-/log-symbols-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/log-symbols/-/log-symbols-3.0.0.tgz",
           "integrity": "sha1-86CFFqXeqJMzan3uFNGKHP2rd8Q=",
           "requires": {
             "chalk": "^2.4.2"
@@ -8660,7 +8740,7 @@
           "dependencies": {
             "ansi-styles": {
               "version": "3.2.1",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
               "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
               "requires": {
                 "color-convert": "^1.9.0"
@@ -8668,7 +8748,7 @@
             },
             "chalk": {
               "version": "2.4.2",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
               "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
               "requires": {
                 "ansi-styles": "^3.2.1",
@@ -8678,7 +8758,7 @@
             },
             "color-convert": {
               "version": "1.9.3",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-convert/-/color-convert-1.9.3.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-convert/-/color-convert-1.9.3.tgz",
               "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
               "requires": {
                 "color-name": "1.1.3"
@@ -8686,22 +8766,22 @@
             },
             "color-name": {
               "version": "1.1.3",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.3.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.3.tgz",
               "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
               "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
             },
             "has-flag": {
               "version": "3.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-3.0.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-flag/-/has-flag-3.0.0.tgz",
               "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
             },
             "supports-color": {
               "version": "5.5.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-5.5.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
               "requires": {
                 "has-flag": "^3.0.0"
@@ -8711,17 +8791,25 @@
         },
         "p-map": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-map/-/p-map-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-map/-/p-map-2.1.0.tgz",
           "integrity": "sha1-MQko/u+cnsxltosXaTAYpmXOoXU="
         },
         "semver": {
           "version": "7.3.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-7.3.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/semver/-/semver-7.3.2.tgz",
           "integrity": "sha1-YElisFK4HtB4aq6EOJ/7pw/9OTg="
+        },
+        "split": {
+          "version": "1.0.1",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/split/-/split-1.0.1.tgz",
+          "integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
+          "requires": {
+            "through": "2"
+          }
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "requires": {
             "has-flag": "^4.0.0"
@@ -8731,7 +8819,7 @@
     },
     "npm-name": {
       "version": "6.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/npm-name/-/npm-name-6.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/npm-name/-/npm-name-6.0.1.tgz",
       "integrity": "sha1-c+BbTLYzJ2amcnsmNeJHu0EHJVs=",
       "requires": {
         "got": "^10.6.0",
@@ -8747,7 +8835,7 @@
       "dependencies": {
         "got": {
           "version": "10.7.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/got/-/got-10.7.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/got/-/got-10.7.0.tgz",
           "integrity": "sha1-YoidvNbMoyzWoVTMLQxolRIdCR8=",
           "requires": {
             "@sindresorhus/is": "^2.0.0",
@@ -8769,19 +8857,19 @@
         },
         "lowercase-keys": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
           "integrity": "sha1-JgPni3tLAAbLyi+8yKMgJVislHk="
         },
         "type-fest": {
           "version": "0.10.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.10.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.10.0.tgz",
           "integrity": "sha1-fwayufv8WBBo0TQf+r0DSc6vxkI="
         }
       }
     },
     "npm-run-path": {
       "version": "4.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
       "requires": {
         "path-key": "^3.0.0"
@@ -8789,7 +8877,7 @@
     },
     "npmlog": {
       "version": "4.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/npmlog/-/npmlog-4.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
       "requires": {
         "are-we-there-yet": "~1.1.2",
@@ -8800,32 +8888,32 @@
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nwsapi": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nwsapi/-/nwsapi-2.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/nwsapi/-/nwsapi-2.2.0.tgz",
       "integrity": "sha1-IEh5qePQaP8qVROcLHcngGgaOLc="
     },
     "oauth-sign": {
       "version": "0.9.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-component": {
       "version": "0.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-component/-/object-component-0.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object-component/-/object-component-0.0.3.tgz",
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
     },
     "object-copy": {
       "version": "0.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-copy/-/object-copy-0.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "requires": {
         "copy-descriptor": "^0.1.0",
@@ -8835,20 +8923,15 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
           }
         },
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
-        },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -8858,36 +8941,57 @@
     },
     "object-inspect": {
       "version": "1.8.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-inspect/-/object-inspect-1.8.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object-inspect/-/object-inspect-1.8.0.tgz",
       "integrity": "sha1-34B+Xs9TpgnMa/6T6sPMe+WzqdA="
     },
     "object-keys": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-keys/-/object-keys-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4="
     },
     "object-visit": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-visit/-/object-visit-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
         "isobject": "^3.0.0"
       }
     },
     "object.assign": {
-      "version": "4.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
+      "version": "4.1.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object.assign/-/object.assign-4.1.1.tgz",
+      "integrity": "sha1-MDhnpmbN1Bk27N7fsfjz4ypHjN0=",
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.0",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0-next.1",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+          "integrity": "sha1-bjoKS9pxflAjqzuOkL7DYQjSLGg=",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-negative-zero": "^2.0.0",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "object.omit": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object.omit/-/object.omit-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "requires": {
         "for-own": "^0.1.4",
@@ -8896,7 +9000,7 @@
     },
     "object.pick": {
       "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object.pick/-/object.pick-1.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
         "isobject": "^3.0.1"
@@ -8904,12 +9008,12 @@
     },
     "obuf": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/obuf/-/obuf-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha1-Cb6jND1BhZ69RGKS0RydTbYZCE4="
     },
     "on-finished": {
       "version": "2.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/on-finished/-/on-finished-2.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "requires": {
         "ee-first": "1.1.1"
@@ -8917,12 +9021,12 @@
     },
     "on-headers": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/on-headers/-/on-headers-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/on-headers/-/on-headers-1.0.2.tgz",
       "integrity": "sha1-dysK5qqlJcOZ5Imt+tkMQD6zwo8="
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/once/-/once-1.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
@@ -8930,7 +9034,7 @@
     },
     "one-time": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/one-time/-/one-time-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/one-time/-/one-time-1.0.0.tgz",
       "integrity": "sha1-4GvBdK7SFO1Y7e3lc7Qzu/gny0U=",
       "requires": {
         "fn.name": "1.x.x"
@@ -8938,16 +9042,16 @@
     },
     "onetime": {
       "version": "5.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/onetime/-/onetime-5.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
       "requires": {
         "mimic-fn": "^2.1.0"
       }
     },
     "open": {
-      "version": "7.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/open/-/open-7.2.1.tgz",
-      "integrity": "sha1-B7Ct4RpD8qjOcYSAvfPXVjoJUZU=",
+      "version": "7.3.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/open/-/open-7.3.0.tgz",
+      "integrity": "sha1-RUYf3uRkRPNkW24U6zypS4Lhvmk=",
       "requires": {
         "is-docker": "^2.0.0",
         "is-wsl": "^2.1.1"
@@ -8955,7 +9059,7 @@
       "dependencies": {
         "is-wsl": {
           "version": "2.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-wsl/-/is-wsl-2.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-wsl/-/is-wsl-2.2.0.tgz",
           "integrity": "sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE=",
           "requires": {
             "is-docker": "^2.0.0"
@@ -8965,12 +9069,12 @@
     },
     "opener": {
       "version": "1.5.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/opener/-/opener-1.5.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/opener/-/opener-1.5.2.tgz",
       "integrity": "sha1-XTfh81B3udysQwE3InGv3rKhNZg="
     },
     "opn": {
       "version": "5.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/opn/-/opn-5.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/opn/-/opn-5.5.0.tgz",
       "integrity": "sha1-/HFk+rVtI1kExRw7J9pnWMo7m/w=",
       "requires": {
         "is-wsl": "^1.1.0"
@@ -8978,7 +9082,7 @@
     },
     "optionator": {
       "version": "0.9.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/optionator/-/optionator-0.9.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/optionator/-/optionator-0.9.1.tgz",
       "integrity": "sha1-TyNqY3Pa4FZqbUPhMmZ09QwpFJk=",
       "requires": {
         "deep-is": "^0.1.3",
@@ -8991,7 +9095,7 @@
     },
     "ordered-read-streams": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
       "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
       "requires": {
         "is-stream": "^1.0.1",
@@ -9000,22 +9104,22 @@
     },
     "org-regex": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/org-regex/-/org-regex-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/org-regex/-/org-regex-1.0.0.tgz",
       "integrity": "sha1-Z+u5qzyxJP6lhBKJ1gtZQ08EGlk="
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
       "version": "0.1.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/osenv/-/osenv-0.1.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
       "requires": {
         "os-homedir": "^1.0.0",
@@ -9024,7 +9128,7 @@
     },
     "ow": {
       "version": "0.15.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ow/-/ow-0.15.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ow/-/ow-0.15.1.tgz",
       "integrity": "sha1-rSG7TUxG1EeLlIUi42shT28TA50=",
       "requires": {
         "type-fest": "^0.8.1"
@@ -9032,17 +9136,17 @@
     },
     "p-cancelable": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-cancelable/-/p-cancelable-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-cancelable/-/p-cancelable-2.0.0.tgz",
       "integrity": "sha1-SjdA9b2vXtXXw+NIgsb7XWsmam4="
     },
     "p-defer": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-defer/-/p-defer-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-defer/-/p-defer-1.0.0.tgz",
       "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
     },
     "p-event": {
       "version": "4.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-event/-/p-event-4.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-event/-/p-event-4.2.0.tgz",
       "integrity": "sha1-r0sEnIrNka6BCD69Hm9criBEwbU=",
       "requires": {
         "p-timeout": "^3.1.0"
@@ -9050,17 +9154,17 @@
     },
     "p-finally": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-finally/-/p-finally-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-is-promise": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-is-promise/-/p-is-promise-2.1.0.tgz",
       "integrity": "sha1-kYzrrqJIpiz3/6uOO8qMX4gvxC4="
     },
     "p-limit": {
       "version": "3.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-limit/-/p-limit-3.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-limit/-/p-limit-3.0.2.tgz",
       "integrity": "sha1-FmTgEK88rcaBuq/T4qQ3vnsPtf4=",
       "requires": {
         "p-try": "^2.0.0"
@@ -9068,7 +9172,7 @@
     },
     "p-locate": {
       "version": "5.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-locate/-/p-locate-5.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha1-g8gxXGeFAF470CGDlBHJ4RDm2DQ=",
       "requires": {
         "p-limit": "^3.0.2"
@@ -9076,7 +9180,7 @@
     },
     "p-map": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-map/-/p-map-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-map/-/p-map-3.0.0.tgz",
       "integrity": "sha1-1wTZr4orpoTiYA2aIVmD1BQal50=",
       "requires": {
         "aggregate-error": "^3.0.0"
@@ -9084,7 +9188,7 @@
     },
     "p-memoize": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-memoize/-/p-memoize-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-memoize/-/p-memoize-3.1.0.tgz",
       "integrity": "sha1-rHWHmDyeUwE5+WnKe0HvQOk2Wao=",
       "requires": {
         "mem": "^4.3.0",
@@ -9093,7 +9197,7 @@
     },
     "p-timeout": {
       "version": "3.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-timeout/-/p-timeout-3.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-timeout/-/p-timeout-3.2.0.tgz",
       "integrity": "sha1-x+F6vJcdKnli74NiazXWNazyPf4=",
       "requires": {
         "p-finally": "^1.0.0"
@@ -9101,12 +9205,12 @@
     },
     "p-try": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-try/-/p-try-2.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY="
     },
     "package-json": {
       "version": "6.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/package-json/-/package-json-6.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/package-json/-/package-json-6.5.0.tgz",
       "integrity": "sha1-b+7ayjXnVyWHbQsOZJdGl/7RRbA=",
       "requires": {
         "got": "^9.6.0",
@@ -9117,12 +9221,12 @@
       "dependencies": {
         "@sindresorhus/is": {
           "version": "0.14.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@sindresorhus/is/-/is-0.14.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@sindresorhus/is/-/is-0.14.0.tgz",
           "integrity": "sha1-n7OjzzEyMoFR81PeRjLgHlIQK+o="
         },
         "@szmarczak/http-timer": {
           "version": "1.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
           "integrity": "sha1-sWZeLEYaLNkvTBu/UNVFTeDUtCE=",
           "requires": {
             "defer-to-connect": "^1.0.1"
@@ -9130,7 +9234,7 @@
         },
         "cacheable-request": {
           "version": "6.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cacheable-request/-/cacheable-request-6.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cacheable-request/-/cacheable-request-6.1.0.tgz",
           "integrity": "sha1-IP+4vRYrpL4R6VZ9gj22UQUsqRI=",
           "requires": {
             "clone-response": "^1.0.2",
@@ -9144,7 +9248,7 @@
           "dependencies": {
             "get-stream": {
               "version": "5.2.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-stream/-/get-stream-5.2.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-stream/-/get-stream-5.2.0.tgz",
               "integrity": "sha1-SWaheV7lrOZecGxLe+txJX1uItM=",
               "requires": {
                 "pump": "^3.0.0"
@@ -9152,14 +9256,14 @@
             },
             "lowercase-keys": {
               "version": "2.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
               "integrity": "sha1-JgPni3tLAAbLyi+8yKMgJVislHk="
             }
           }
         },
         "decompress-response": {
           "version": "3.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/decompress-response/-/decompress-response-3.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/decompress-response/-/decompress-response-3.3.0.tgz",
           "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
           "requires": {
             "mimic-response": "^1.0.0"
@@ -9167,12 +9271,12 @@
         },
         "defer-to-connect": {
           "version": "1.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
           "integrity": "sha1-MxrgUMCNz3ifjIOnuB8O2U9KxZE="
         },
         "get-stream": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-stream/-/get-stream-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-stream/-/get-stream-4.1.0.tgz",
           "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
           "requires": {
             "pump": "^3.0.0"
@@ -9180,7 +9284,7 @@
         },
         "got": {
           "version": "9.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/got/-/got-9.6.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/got/-/got-9.6.0.tgz",
           "integrity": "sha1-7fRefWf5lUVwXeH3u+7rEhdl7YU=",
           "requires": {
             "@sindresorhus/is": "^0.14.0",
@@ -9198,12 +9302,12 @@
         },
         "json-buffer": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-buffer/-/json-buffer-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/json-buffer/-/json-buffer-3.0.0.tgz",
           "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
         },
         "keyv": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/keyv/-/keyv-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/keyv/-/keyv-3.1.0.tgz",
           "integrity": "sha1-7MIoSG9pmR5J6UdkhaW+Ho/FxNk=",
           "requires": {
             "json-buffer": "3.0.0"
@@ -9211,22 +9315,22 @@
         },
         "mimic-response": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mimic-response/-/mimic-response-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mimic-response/-/mimic-response-1.0.1.tgz",
           "integrity": "sha1-SSNTiHju9CBjy4o+OweYeBSHqxs="
         },
         "p-cancelable": {
           "version": "1.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-cancelable/-/p-cancelable-1.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-cancelable/-/p-cancelable-1.1.0.tgz",
           "integrity": "sha1-0HjRWjr0CSIMiG8dmgyi5EGrJsw="
         },
         "prepend-http": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/prepend-http/-/prepend-http-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/prepend-http/-/prepend-http-2.0.0.tgz",
           "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
         },
         "responselike": {
           "version": "1.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/responselike/-/responselike-1.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/responselike/-/responselike-1.0.2.tgz",
           "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
           "requires": {
             "lowercase-keys": "^1.0.0"
@@ -9234,17 +9338,17 @@
         },
         "semver": {
           "version": "6.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/semver/-/semver-6.3.0.tgz",
           "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0="
         },
         "to-readable-stream": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
           "integrity": "sha1-zgqgwvPfat+FLvtASng+d8BHV3E="
         },
         "url-parse-lax": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
           "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
           "requires": {
             "prepend-http": "^2.0.0"
@@ -9254,12 +9358,12 @@
     },
     "pako": {
       "version": "1.0.11",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pako/-/pako-1.0.11.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pako/-/pako-1.0.11.tgz",
       "integrity": "sha1-bJWZ00DVTf05RjgCUqNXBaa5kr8="
     },
     "param-case": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/param-case/-/param-case-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/param-case/-/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "requires": {
         "no-case": "^2.2.0"
@@ -9267,7 +9371,7 @@
     },
     "parent-module": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parent-module/-/parent-module-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
       "requires": {
         "callsites": "^3.0.0"
@@ -9275,7 +9379,7 @@
     },
     "parse-glob": {
       "version": "3.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse-glob/-/parse-glob-3.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "requires": {
         "glob-base": "^0.3.0",
@@ -9286,12 +9390,12 @@
       "dependencies": {
         "is-extglob": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
         },
         "is-glob": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "requires": {
             "is-extglob": "^1.0.0"
@@ -9301,7 +9405,7 @@
     },
     "parse-json": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse-json/-/parse-json-2.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "requires": {
         "error-ex": "^1.2.0"
@@ -9309,17 +9413,17 @@
     },
     "parse-passwd": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
     },
     "parse5": {
       "version": "5.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse5/-/parse5-5.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse5/-/parse5-5.1.1.tgz",
       "integrity": "sha1-9o5OW6GFKsLK3AD0VV//bCq7YXg="
     },
     "parseqs": {
       "version": "0.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parseqs/-/parseqs-0.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "requires": {
         "better-assert": "~1.0.0"
@@ -9327,7 +9431,7 @@
     },
     "parseuri": {
       "version": "0.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parseuri/-/parseuri-0.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "requires": {
         "better-assert": "~1.0.0"
@@ -9335,62 +9439,62 @@
     },
     "parseurl": {
       "version": "1.3.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parseurl/-/parseurl-1.3.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha1-naGee+6NEt/wUT7Vt2lXeTvC6NQ="
     },
     "pascalcase": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pascalcase/-/pascalcase-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
     },
     "path-dirname": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-dirname/-/path-dirname-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
     },
     "path-exists": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-exists/-/path-exists-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM="
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
     },
     "path-key": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-key/-/path-key-3.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U="
     },
     "path-parse": {
       "version": "1.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-parse/-/path-parse-1.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw="
     },
     "path-to-regexp": {
       "version": "2.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
       "integrity": "sha1-Nc5/Mz1WFvHB4b/iZsOrouWy5wQ="
     },
     "path-type": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-type/-/path-type-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha1-hO0BwKe6OAr+CdkKjBgNzZ0DBDs="
     },
     "pathval": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pathval/-/pathval-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
     },
     "pause-stream": {
       "version": "0.0.11",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pause-stream/-/pause-stream-0.0.11.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "requires": {
         "through": "~2.3"
@@ -9398,7 +9502,7 @@
     },
     "pem": {
       "version": "1.14.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pem/-/pem-1.14.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pem/-/pem-1.14.4.tgz",
       "integrity": "sha1-poxwxudRzMWztbzXr3iwrsEXf/k=",
       "requires": {
         "es6-promisify": "^6.0.0",
@@ -9409,7 +9513,7 @@
       "dependencies": {
         "which": {
           "version": "2.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/which/-/which-2.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/which/-/which-2.0.2.tgz",
           "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
           "requires": {
             "isexe": "^2.0.0"
@@ -9419,32 +9523,32 @@
     },
     "pend": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pend/-/pend-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
       "version": "2.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/picomatch/-/picomatch-2.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha1-IfMz6ba46v8CRo9RRupAbTRfTa0="
     },
     "pify": {
       "version": "4.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pify/-/pify-4.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pify/-/pify-4.0.1.tgz",
       "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE="
     },
     "pinkie": {
       "version": "2.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pinkie/-/pinkie-2.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
         "pinkie": "^2.0.0"
@@ -9452,7 +9556,7 @@
     },
     "pkg-dir": {
       "version": "4.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
       "requires": {
         "find-up": "^4.0.0"
@@ -9460,7 +9564,7 @@
       "dependencies": {
         "find-up": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-up/-/find-up-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/find-up/-/find-up-4.1.0.tgz",
           "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
           "requires": {
             "locate-path": "^5.0.0",
@@ -9469,7 +9573,7 @@
         },
         "locate-path": {
           "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/locate-path/-/locate-path-5.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/locate-path/-/locate-path-5.0.0.tgz",
           "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
           "requires": {
             "p-locate": "^4.1.0"
@@ -9477,7 +9581,7 @@
         },
         "p-limit": {
           "version": "2.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-limit/-/p-limit-2.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-limit/-/p-limit-2.3.0.tgz",
           "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
           "requires": {
             "p-try": "^2.0.0"
@@ -9485,7 +9589,7 @@
         },
         "p-locate": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-locate/-/p-locate-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-locate/-/p-locate-4.1.0.tgz",
           "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
           "requires": {
             "p-limit": "^2.2.0"
@@ -9495,18 +9599,26 @@
     },
     "plist": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/plist/-/plist-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/plist/-/plist-2.1.0.tgz",
       "integrity": "sha1-V8zbeggh3yGDEhejytVOPhRqECU=",
       "optional": true,
       "requires": {
         "base64-js": "1.2.0",
         "xmlbuilder": "8.2.2",
         "xmldom": "0.1.x"
+      },
+      "dependencies": {
+        "xmlbuilder": {
+          "version": "8.2.2",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+          "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
+          "optional": true
+        }
       }
     },
     "plylog": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/plylog/-/plylog-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/plylog/-/plylog-1.1.0.tgz",
       "integrity": "sha1-9vNU4q4LAfbbTtER9LOFXanDdBc=",
       "requires": {
         "logform": "^1.9.1",
@@ -9516,7 +9628,7 @@
     },
     "polymer-analyzer": {
       "version": "3.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/polymer-analyzer/-/polymer-analyzer-3.2.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/polymer-analyzer/-/polymer-analyzer-3.2.4.tgz",
       "integrity": "sha1-fXY1ZiCiMo6LyeMORwaflykmDKE=",
       "requires": {
         "@babel/generator": "^7.0.0-beta.42",
@@ -9560,12 +9672,12 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -9577,7 +9689,7 @@
         },
         "doctrine": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/doctrine/-/doctrine-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/doctrine/-/doctrine-2.1.0.tgz",
           "integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
           "requires": {
             "esutils": "^2.0.2"
@@ -9585,24 +9697,24 @@
         },
         "parse5": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse5/-/parse5-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse5/-/parse5-4.0.0.tgz",
           "integrity": "sha1-bXhlbj2o14tOwLkG98CO8d/j9gg="
         },
         "strip-indent": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-indent/-/strip-indent-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-indent/-/strip-indent-2.0.0.tgz",
           "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
     "polymer-build": {
       "version": "3.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/polymer-build/-/polymer-build-3.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/polymer-build/-/polymer-build-3.1.4.tgz",
       "integrity": "sha1-q1OfGhPYA1GLE7c//QkZhDHZgUI=",
       "requires": {
         "@babel/core": "^7.0.0",
@@ -9674,7 +9786,7 @@
       "dependencies": {
         "@types/mz": {
           "version": "0.0.31",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/mz/-/mz-0.0.31.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/mz/-/mz-0.0.31.tgz",
           "integrity": "sha1-pNgMCC/v5x5Ap8DwfR5lVbu8e1I=",
           "requires": {
             "@types/node": "*"
@@ -9682,7 +9794,7 @@
         },
         "@types/resolve": {
           "version": "0.0.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/resolve/-/resolve-0.0.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/resolve/-/resolve-0.0.7.tgz",
           "integrity": "sha1-spnBO+jXErG1AvsUoIQlKs74T00=",
           "requires": {
             "@types/node": "*"
@@ -9690,12 +9802,12 @@
         },
         "commander": {
           "version": "2.17.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/commander/-/commander-2.17.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/commander/-/commander-2.17.1.tgz",
           "integrity": "sha1-vXerfebelCBc6sxy8XFtKfIKd78="
         },
         "html-minifier": {
           "version": "3.5.21",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/html-minifier/-/html-minifier-3.5.21.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/html-minifier/-/html-minifier-3.5.21.tgz",
           "integrity": "sha1-0AQOBUcw41TbAIRjWTGUAVIS0gw=",
           "requires": {
             "camel-case": "3.0.x",
@@ -9709,12 +9821,12 @@
         },
         "parse5": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse5/-/parse5-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse5/-/parse5-4.0.0.tgz",
           "integrity": "sha1-bXhlbj2o14tOwLkG98CO8d/j9gg="
         },
         "uglify-js": {
           "version": "3.4.10",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/uglify-js/-/uglify-js-3.4.10.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/uglify-js/-/uglify-js-3.4.10.tgz",
           "integrity": "sha1-mtlWPY6zrN+404WX0q8dgV9qdV8=",
           "requires": {
             "commander": "~2.19.0",
@@ -9723,7 +9835,7 @@
           "dependencies": {
             "commander": {
               "version": "2.19.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/commander/-/commander-2.19.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/commander/-/commander-2.19.0.tgz",
               "integrity": "sha1-9hmKqE5bg8RgVLlN3tv+1e6f8So="
             }
           }
@@ -9732,7 +9844,7 @@
     },
     "polymer-bundler": {
       "version": "4.0.10",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/polymer-bundler/-/polymer-bundler-4.0.10.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/polymer-bundler/-/polymer-bundler-4.0.10.tgz",
       "integrity": "sha1-q8jTOXdlLwMQaNA0yBBIQegNTLs=",
       "requires": {
         "@types/babel-generator": "^6.25.1",
@@ -9756,12 +9868,12 @@
       "dependencies": {
         "acorn": {
           "version": "5.7.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn/-/acorn-5.7.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/acorn/-/acorn-5.7.4.tgz",
           "integrity": "sha1-Po2KmUfQWZoXltECJddDL0pKz14="
         },
         "acorn-jsx": {
           "version": "3.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
           "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
           "requires": {
             "acorn": "^3.0.4"
@@ -9769,14 +9881,14 @@
           "dependencies": {
             "acorn": {
               "version": "3.3.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn/-/acorn-3.3.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/acorn/-/acorn-3.3.0.tgz",
               "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
             }
           }
         },
         "espree": {
           "version": "3.5.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/espree/-/espree-3.5.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/espree/-/espree-3.5.4.tgz",
           "integrity": "sha1-sPRHGHyKi+2US4FaZgvd9d610ac=",
           "requires": {
             "acorn": "^5.5.0",
@@ -9785,19 +9897,19 @@
         },
         "parse5": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse5/-/parse5-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse5/-/parse5-4.0.0.tgz",
           "integrity": "sha1-bXhlbj2o14tOwLkG98CO8d/j9gg="
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
     "polymer-project-config": {
       "version": "4.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/polymer-project-config/-/polymer-project-config-4.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/polymer-project-config/-/polymer-project-config-4.0.3.tgz",
       "integrity": "sha1-7wwaZ2zkgJkHmGyOkQdFZg3oAk8=",
       "requires": {
         "@types/parse5": "^2.2.34",
@@ -9810,7 +9922,7 @@
     },
     "polyserve": {
       "version": "0.27.15",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/polyserve/-/polyserve-0.27.15.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/polyserve/-/polyserve-0.27.15.tgz",
       "integrity": "sha1-Jh+loIc8jZX9cGhZj0TJ2sIM+cQ=",
       "requires": {
         "@types/compression": "^0.0.33",
@@ -9851,7 +9963,7 @@
       "dependencies": {
         "lru-cache": {
           "version": "4.1.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lru-cache/-/lru-cache-4.1.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lru-cache/-/lru-cache-4.1.5.tgz",
           "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
           "requires": {
             "pseudomap": "^1.0.2",
@@ -9860,12 +9972,12 @@
         },
         "mime": {
           "version": "2.4.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mime/-/mime-2.4.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mime/-/mime-2.4.6.tgz",
           "integrity": "sha1-5bQHyQ20QvK+tbFiNz0Htpr/pNE="
         },
         "opn": {
           "version": "3.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/opn/-/opn-3.0.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/opn/-/opn-3.0.3.tgz",
           "integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
           "requires": {
             "object-assign": "^4.0.1"
@@ -9873,19 +9985,19 @@
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yallist/-/yallist-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
         }
       }
     },
     "popper.js": {
       "version": "1.16.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/popper.js/-/popper.js-1.16.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/popper.js/-/popper.js-1.16.1.tgz",
       "integrity": "sha1-KiI8s9x7YhPXQOQDcr5A3kPmWxs="
     },
     "portfinder": {
       "version": "1.0.28",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/portfinder/-/portfinder-1.0.28.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/portfinder/-/portfinder-1.0.28.tgz",
       "integrity": "sha1-Z8RiKFK9U3TdHdkA93n1NGL6x3g=",
       "requires": {
         "async": "^2.6.2",
@@ -9895,47 +10007,42 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-3.2.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-3.2.6.tgz",
           "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         }
       }
     },
     "posix-character-classes": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "prelude-ls": {
       "version": "1.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha1-3rxkidem5rDnYRiIzsiAM30xY5Y="
     },
     "prepend-http": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/prepend-http/-/prepend-http-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
     "preserve": {
       "version": "0.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/preserve/-/preserve-0.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "pretty-bytes": {
       "version": "4.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
       "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
     },
     "prismjs": {
       "version": "1.12.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/prismjs/-/prismjs-1.12.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/prismjs/-/prismjs-1.12.2.tgz",
       "integrity": "sha1-pAps1b82cW4xbLdd+Rl2p9XWlOY=",
       "requires": {
         "clipboard": "^2.0.0"
@@ -9943,17 +10050,17 @@
     },
     "process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
     },
     "progress": {
       "version": "2.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/progress/-/progress-2.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/progress/-/progress-2.0.3.tgz",
       "integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg="
     },
     "proj4": {
       "version": "2.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/proj4/-/proj4-2.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/proj4/-/proj4-2.2.1.tgz",
       "integrity": "sha1-rEFc19SyWFMFAtiwbyntpdTQHwY=",
       "requires": {
         "mgrs": "0.0.0"
@@ -9961,43 +10068,55 @@
     },
     "promise-polyfill": {
       "version": "7.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/promise-polyfill/-/promise-polyfill-7.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/promise-polyfill/-/promise-polyfill-7.0.0.tgz",
       "integrity": "sha1-xmW22h+X4hw/L3qgVDyQIJEnyxU="
-    },
-    "promise.allsettled": {
-      "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/promise.allsettled/-/promise.allsettled-1.0.2.tgz",
-      "integrity": "sha1-1m94+7YA6D6GPYk+mLPUN2qcR8k=",
-      "requires": {
-        "array.prototype.map": "^1.0.1",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1",
-        "function-bind": "^1.1.1",
-        "iterate-value": "^1.0.0"
-      }
     },
     "proxy-addr": {
       "version": "2.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/proxy-addr/-/proxy-addr-2.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/proxy-addr/-/proxy-addr-2.0.6.tgz",
       "integrity": "sha1-/cIzZQVEfT8vLGOO0nLK9hS7sr8=",
       "requires": {
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.1"
       }
     },
+    "ps-tree": {
+      "version": "1.2.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ps-tree/-/ps-tree-1.2.0.tgz",
+      "integrity": "sha1-XnQluJUIc2zdTyIk0Cj3uz9yLr0=",
+      "requires": {
+        "event-stream": "=3.3.4"
+      },
+      "dependencies": {
+        "event-stream": {
+          "version": "3.3.4",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/event-stream/-/event-stream-3.3.4.tgz",
+          "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+          "requires": {
+            "duplexer": "~0.1.1",
+            "from": "~0",
+            "map-stream": "~0.1.0",
+            "pause-stream": "0.0.11",
+            "split": "0.3",
+            "stream-combiner": "~0.0.4",
+            "through": "~2.3.1"
+          }
+        }
+      }
+    },
     "pseudomap": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pseudomap/-/pseudomap-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
       "version": "1.8.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/psl/-/psl-1.8.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/psl/-/psl-1.8.0.tgz",
       "integrity": "sha1-kyb4vPsBOtzABf3/BWrM4CDlHCQ="
     },
     "pump": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pump/-/pump-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pump/-/pump-3.0.0.tgz",
       "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
       "requires": {
         "end-of-stream": "^1.1.0",
@@ -10006,47 +10125,47 @@
     },
     "punycode": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/punycode/-/punycode-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
     },
     "pupa": {
-      "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pupa/-/pupa-2.0.1.tgz",
-      "integrity": "sha1-29yf9I/76komoGm2+fersFEAhyY=",
+      "version": "2.1.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pupa/-/pupa-2.1.0.tgz",
+      "integrity": "sha1-nk7Fh5UrXk8sBv5Xew59uX6O9yE=",
       "requires": {
         "escape-goat": "^2.0.0"
       },
       "dependencies": {
         "escape-goat": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/escape-goat/-/escape-goat-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/escape-goat/-/escape-goat-2.1.1.tgz",
           "integrity": "sha1-Gy3HcANnbEV+x2Cy3GjttkgYhnU="
         }
       }
     },
     "q": {
       "version": "1.5.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/q/-/q-1.5.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
       "version": "6.5.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/qs/-/qs-6.5.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/qs/-/qs-6.5.2.tgz",
       "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
     },
     "querystring": {
       "version": "0.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/querystring/-/querystring-0.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "quick-lru": {
       "version": "4.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/quick-lru/-/quick-lru-4.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/quick-lru/-/quick-lru-4.0.1.tgz",
       "integrity": "sha1-W4h48ROlgheEjGSCAmxz4bpXcn8="
     },
     "randomatic": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/randomatic/-/randomatic-3.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/randomatic/-/randomatic-3.1.1.tgz",
       "integrity": "sha1-t3bvxZN1mE42xTey9RofCv8Noe0=",
       "requires": {
         "is-number": "^4.0.0",
@@ -10056,14 +10175,14 @@
       "dependencies": {
         "is-number": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-number/-/is-number-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-number/-/is-number-4.0.0.tgz",
           "integrity": "sha1-ACbjf1RU1z41bf5lZGmYZ8an8P8="
         }
       }
     },
     "randombytes": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/randombytes/-/randombytes-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
       "requires": {
         "safe-buffer": "^5.1.0"
@@ -10071,12 +10190,12 @@
     },
     "range-parser": {
       "version": "1.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/range-parser/-/range-parser-1.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha1-PPNwI9GZ4cJNGlW4SADC8+ZGgDE="
     },
     "raw-body": {
       "version": "2.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/raw-body/-/raw-body-2.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/raw-body/-/raw-body-2.4.0.tgz",
       "integrity": "sha1-oc5vucm8NWylLoklarWQWeE9AzI=",
       "requires": {
         "bytes": "3.1.0",
@@ -10087,7 +10206,7 @@
     },
     "rc": {
       "version": "1.2.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rc/-/rc-1.2.8.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/rc/-/rc-1.2.8.tgz",
       "integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
       "requires": {
         "deep-extend": "^0.6.0",
@@ -10098,14 +10217,14 @@
       "dependencies": {
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         }
       }
     },
     "read-all-stream": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/read-all-stream/-/read-all-stream-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/read-all-stream/-/read-all-stream-3.1.0.tgz",
       "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
       "requires": {
         "pinkie-promise": "^2.0.0",
@@ -10114,7 +10233,7 @@
     },
     "read-pkg": {
       "version": "5.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/read-pkg/-/read-pkg-5.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/read-pkg/-/read-pkg-5.2.0.tgz",
       "integrity": "sha1-e/KVQ4yloz5WzTDgU7NO5yUMk8w=",
       "requires": {
         "@types/normalize-package-data": "^2.4.0",
@@ -10125,7 +10244,7 @@
       "dependencies": {
         "parse-json": {
           "version": "5.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse-json/-/parse-json-5.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse-json/-/parse-json-5.1.0.tgz",
           "integrity": "sha1-+WCIzfJKj6qa6poAny2dlCyZlkY=",
           "requires": {
             "@babel/code-frame": "^7.0.0",
@@ -10136,14 +10255,14 @@
         },
         "type-fest": {
           "version": "0.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.6.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.6.0.tgz",
           "integrity": "sha1-jSojcNPfiG61yQraHFv2GIrPg4s="
         }
       }
     },
     "read-pkg-up": {
       "version": "7.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
       "integrity": "sha1-86YTV1hFlzOuK5VjgFbhhU5+9Qc=",
       "requires": {
         "find-up": "^4.1.0",
@@ -10153,7 +10272,7 @@
       "dependencies": {
         "find-up": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-up/-/find-up-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/find-up/-/find-up-4.1.0.tgz",
           "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
           "requires": {
             "locate-path": "^5.0.0",
@@ -10162,7 +10281,7 @@
         },
         "locate-path": {
           "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/locate-path/-/locate-path-5.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/locate-path/-/locate-path-5.0.0.tgz",
           "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
           "requires": {
             "p-locate": "^4.1.0"
@@ -10170,7 +10289,7 @@
         },
         "p-limit": {
           "version": "2.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-limit/-/p-limit-2.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-limit/-/p-limit-2.3.0.tgz",
           "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
           "requires": {
             "p-try": "^2.0.0"
@@ -10178,7 +10297,7 @@
         },
         "p-locate": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-locate/-/p-locate-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-locate/-/p-locate-4.1.0.tgz",
           "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
           "requires": {
             "p-limit": "^2.2.0"
@@ -10188,7 +10307,7 @@
     },
     "readable-stream": {
       "version": "2.3.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-2.3.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -10202,12 +10321,12 @@
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -10216,16 +10335,16 @@
       }
     },
     "readdirp": {
-      "version": "3.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readdirp/-/readdirp-3.4.0.tgz",
-      "integrity": "sha1-n9zN+ekVWAVEkiGsZF6DA6tbmto=",
+      "version": "3.5.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha1-m6dMAZsV02UnjS6Ru4xI17TULJ4=",
       "requires": {
         "picomatch": "^2.2.1"
       }
     },
     "redent": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/redent/-/redent-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/redent/-/redent-3.0.0.tgz",
       "integrity": "sha1-5Ve3mYMWu1PJ8fVvpiY1LGljBZ8=",
       "requires": {
         "indent-string": "^4.0.0",
@@ -10234,12 +10353,12 @@
     },
     "reduce-flatten": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
       "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc="
     },
     "redux": {
       "version": "3.7.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/redux/-/redux-3.7.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/redux/-/redux-3.7.2.tgz",
       "integrity": "sha1-BrcxIyFZAdJdBlvjQusCa8HIU3s=",
       "requires": {
         "lodash": "^4.2.1",
@@ -10250,12 +10369,12 @@
     },
     "regenerate": {
       "version": "1.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regenerate/-/regenerate-1.4.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regenerate/-/regenerate-1.4.1.tgz",
       "integrity": "sha1-ytkq2Oa1kXc0hfvgWkhcr09Ffm8="
     },
     "regenerate-unicode-properties": {
       "version": "8.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
       "integrity": "sha1-5d5xEdZV57pgwFfb6f83yH5lzew=",
       "requires": {
         "regenerate": "^1.4.0"
@@ -10263,12 +10382,12 @@
     },
     "regenerator-runtime": {
       "version": "0.11.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk="
     },
     "regenerator-transform": {
       "version": "0.14.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
       "integrity": "sha1-yY2hVGg2ccnE3LFuznNlF+G3/rQ=",
       "requires": {
         "@babel/runtime": "^7.8.4"
@@ -10276,7 +10395,7 @@
     },
     "regex-cache": {
       "version": "0.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regex-cache/-/regex-cache-0.4.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
       "requires": {
         "is-equal-shallow": "^0.1.3"
@@ -10284,7 +10403,7 @@
     },
     "regex-not": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regex-not/-/regex-not-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
       "requires": {
         "extend-shallow": "^3.0.2",
@@ -10293,13 +10412,13 @@
     },
     "regexpp": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regexpp/-/regexpp-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regexpp/-/regexpp-3.1.0.tgz",
       "integrity": "sha1-IG0K0KVkjP+9uK5GQ489xRyfeOI="
     },
     "regexpu-core": {
-      "version": "4.7.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regexpu-core/-/regexpu-core-4.7.0.tgz",
-      "integrity": "sha1-/L9FjFBDGwu3tF1pZ7gZLZHz2Tg=",
+      "version": "4.7.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regexpu-core/-/regexpu-core-4.7.1.tgz",
+      "integrity": "sha1-LepamgcjMpj78NuR+pq8TG4PitY=",
       "requires": {
         "regenerate": "^1.4.0",
         "regenerate-unicode-properties": "^8.2.0",
@@ -10311,7 +10430,7 @@
     },
     "registry-auth-token": {
       "version": "4.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/registry-auth-token/-/registry-auth-token-4.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/registry-auth-token/-/registry-auth-token-4.2.0.tgz",
       "integrity": "sha1-HTff/acrvs0PWB5HFVQCE6Zet9o=",
       "requires": {
         "rc": "^1.2.8"
@@ -10319,7 +10438,7 @@
     },
     "registry-url": {
       "version": "5.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/registry-url/-/registry-url-5.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/registry-url/-/registry-url-5.1.0.tgz",
       "integrity": "sha1-6YM0tQ1UNLgRNrROxjjZwgCcUAk=",
       "requires": {
         "rc": "^1.2.8"
@@ -10327,12 +10446,12 @@
     },
     "regjsgen": {
       "version": "0.5.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regjsgen/-/regjsgen-0.5.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regjsgen/-/regjsgen-0.5.2.tgz",
       "integrity": "sha1-kv8pX7He7L9uzaslQ9IH6RqjNzM="
     },
     "regjsparser": {
       "version": "0.6.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regjsparser/-/regjsparser-0.6.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regjsparser/-/regjsparser-0.6.4.tgz",
       "integrity": "sha1-p2n4aEMIQBpm6bUp0kNv9NBmYnI=",
       "requires": {
         "jsesc": "~0.5.0"
@@ -10340,34 +10459,34 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
       }
     },
     "relateurl": {
       "version": "0.2.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/relateurl/-/relateurl-0.2.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
     },
     "repeat-element": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/repeat-element/-/repeat-element-1.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/repeat-element/-/repeat-element-1.1.3.tgz",
       "integrity": "sha1-eC4NglwMWjuzlzH4Tv7mt0Lmsc4="
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/repeat-string/-/repeat-string-1.6.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "repeating": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/repeating/-/repeating-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
         "is-finite": "^1.0.0"
@@ -10375,7 +10494,7 @@
     },
     "replace": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/replace/-/replace-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/replace/-/replace-1.2.0.tgz",
       "integrity": "sha1-ol2iiIQaqyLw9+ldwdJJ29LtbiY=",
       "requires": {
         "chalk": "2.4.2",
@@ -10383,26 +10502,162 @@
         "yargs": "^15.3.1"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U="
+        },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
           }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha1-UR1wLAxOQcoVbX0OlgIfI+EyJbE=",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc="
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0="
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha1-6Tk7oHEC5skaOyIUePAlfNKFblM=",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "4.3.0",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+              "requires": {
+                "color-convert": "^2.0.1"
+              }
+            }
+          }
+        },
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha1-DYehbeAa7p2L7Cv7909nhRcw9Pg=",
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha1-vmjEl1xrKr9GkjawyHA2L6sJp7A=",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
         }
       }
     },
     "replace-ext": {
       "version": "0.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/replace-ext/-/replace-ext-0.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/replace-ext/-/replace-ext-0.0.1.tgz",
       "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
     },
     "request": {
       "version": "2.88.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/request/-/request-2.88.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/request/-/request-2.88.2.tgz",
       "integrity": "sha1-1zyRhzHLWofaBH4gcjQUb2ZNErM=",
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -10429,7 +10684,7 @@
     },
     "request-promise-core": {
       "version": "1.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/request-promise-core/-/request-promise-core-1.1.4.tgz",
       "integrity": "sha1-Pu3UIjII1BmGe3jOgVFn0QWToi8=",
       "requires": {
         "lodash": "^4.17.19"
@@ -10437,7 +10692,7 @@
     },
     "request-promise-native": {
       "version": "1.0.9",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/request-promise-native/-/request-promise-native-1.0.9.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/request-promise-native/-/request-promise-native-1.0.9.tgz",
       "integrity": "sha1-5AcSBSal79yaObKKVnm/R7nZ3Cg=",
       "requires": {
         "request-promise-core": "1.1.4",
@@ -10447,35 +10702,36 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs="
     },
     "requirejs": {
       "version": "2.3.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/requirejs/-/requirejs-2.3.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/requirejs/-/requirejs-2.3.6.tgz",
       "integrity": "sha1-5Qk9lgHCgpJRJYwLlEXU0Z+p58k="
     },
     "requires-port": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/requires-port/-/requires-port-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
-      "version": "1.17.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha1-sllBtUloIxzC0bt2p5y38sC/hEQ=",
+      "version": "1.18.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/resolve/-/resolve-1.18.1.tgz",
+      "integrity": "sha1-AY/LLFsgfSpkJK7jYcWiZtqPQTA=",
       "requires": {
+        "is-core-module": "^2.0.0",
         "path-parse": "^1.0.6"
       }
     },
     "resolve-dir": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/resolve-dir/-/resolve-dir-1.0.1.tgz",
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "requires": {
         "expand-tilde": "^2.0.0",
@@ -10484,17 +10740,17 @@
     },
     "resolve-from": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/resolve-from/-/resolve-from-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY="
     },
     "resolve-url": {
       "version": "0.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/resolve-url/-/resolve-url-0.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
     "responselike": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/responselike/-/responselike-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/responselike/-/responselike-2.0.0.tgz",
       "integrity": "sha1-JjkbzDF091D5p56sxAoSpcQtdyM=",
       "requires": {
         "lowercase-keys": "^2.0.0"
@@ -10502,14 +10758,14 @@
       "dependencies": {
         "lowercase-keys": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
           "integrity": "sha1-JgPni3tLAAbLyi+8yKMgJVislHk="
         }
       }
     },
     "restore-cursor": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha1-OfZ8VLOnpYzqUjbZXPADQjljH34=",
       "requires": {
         "onetime": "^5.1.0",
@@ -10518,17 +10774,17 @@
     },
     "ret": {
       "version": "0.1.15",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ret/-/ret-0.1.15.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ret/-/ret-0.1.15.tgz",
       "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w="
     },
     "reusify": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/reusify/-/reusify-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha1-kNo4Kx4SbvwCFG6QhFqI2xKSXXY="
     },
     "rimraf": {
       "version": "2.7.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rimraf/-/rimraf-2.7.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
       "requires": {
         "glob": "^7.1.3"
@@ -10536,7 +10792,7 @@
     },
     "rollup": {
       "version": "1.32.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rollup/-/rollup-1.32.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/rollup/-/rollup-1.32.1.tgz",
       "integrity": "sha1-RIDlLZ2eKuS0a6DZ3erzFjlA+cQ=",
       "requires": {
         "@types/estree": "*",
@@ -10546,17 +10802,17 @@
     },
     "run-async": {
       "version": "2.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/run-async/-/run-async-2.4.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/run-async/-/run-async-2.4.1.tgz",
       "integrity": "sha1-hEDsz5nqPnC9QJ1JqriOEMGJpFU="
     },
     "run-parallel": {
       "version": "1.1.9",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/run-parallel/-/run-parallel-1.1.9.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/run-parallel/-/run-parallel-1.1.9.tgz",
       "integrity": "sha1-yd06fPn0ssS2JE4XOm7YZuYd1nk="
     },
     "rxjs": {
       "version": "6.6.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rxjs/-/rxjs-6.6.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/rxjs/-/rxjs-6.6.3.tgz",
       "integrity": "sha1-jKhGNcTaqQDA05Z6buesYCce5VI=",
       "requires": {
         "tslib": "^1.9.0"
@@ -10564,12 +10820,12 @@
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -10577,25 +10833,25 @@
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
     },
     "samsam": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/samsam/-/samsam-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/samsam/-/samsam-1.1.2.tgz",
       "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc="
     },
     "sass": {
-      "version": "1.26.10",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sass/-/sass-1.26.10.tgz",
-      "integrity": "sha1-hR0SYCHNyT3svyAdHsoqIO5DR2A=",
+      "version": "1.27.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sass/-/sass-1.27.0.tgz",
+      "integrity": "sha1-Blf/Z0IGuV7CDcY4qT4XnHj2raI=",
       "requires": {
         "chokidar": ">=2.0.0 <4.0.0"
       }
     },
     "sauce-connect-launcher": {
       "version": "1.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sauce-connect-launcher/-/sauce-connect-launcher-1.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sauce-connect-launcher/-/sauce-connect-launcher-1.3.2.tgz",
       "integrity": "sha1-38Z1olhVCAmo6vRX65FiuUPduvA=",
       "optional": true,
       "requires": {
@@ -10604,16 +10860,37 @@
         "https-proxy-agent": "^5.0.0",
         "lodash": "^4.16.6",
         "rimraf": "^2.5.4"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "6.0.1",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/agent-base/-/agent-base-6.0.1.tgz",
+          "integrity": "sha1-gIAH5OWGfeywq2qy+Sj721pZbbQ=",
+          "optional": true,
+          "requires": {
+            "debug": "4"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha1-4qkFQqu2inYuCghQ9sntrf2FBrI=",
+          "optional": true,
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
+        }
       }
     },
     "sax": {
       "version": "1.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sax/-/sax-1.2.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sax/-/sax-1.2.4.tgz",
       "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
     },
     "saxes": {
       "version": "5.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/saxes/-/saxes-5.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/saxes/-/saxes-5.0.1.tgz",
       "integrity": "sha1-7rq5U/o7dgjb6U5drbFciI+maW0=",
       "requires": {
         "xmlchars": "^2.2.0"
@@ -10621,105 +10898,65 @@
     },
     "scoped-regex": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/scoped-regex/-/scoped-regex-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/scoped-regex/-/scoped-regex-2.1.0.tgz",
       "integrity": "sha1-e5voRdgf2dIdHsl8YaC3z4bSAV8="
     },
     "secure-compare": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/secure-compare/-/secure-compare-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/secure-compare/-/secure-compare-3.0.1.tgz",
       "integrity": "sha1-8aAymzCLIh+uN7mXTz1XjQypmeM="
     },
     "select": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/select/-/select-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/select/-/select-1.1.2.tgz",
       "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
     },
     "select-hose": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/select-hose/-/select-hose-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/select-hose/-/select-hose-2.0.0.tgz",
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "selenium-standalone": {
-      "version": "6.20.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/selenium-standalone/-/selenium-standalone-6.20.0.tgz",
-      "integrity": "sha1-IWOHDh3VOOYmwH1Q3sYEmfz+fns=",
+      "version": "6.20.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/selenium-standalone/-/selenium-standalone-6.20.1.tgz",
+      "integrity": "sha1-gh0Dkv8l4OvQXjLs+AimNj5kKY4=",
       "optional": true,
       "requires": {
-        "async": "^2.6.2",
+        "async": "^3.0.0",
         "commander": "^2.19.0",
-        "cross-spawn": "^6.0.5",
+        "cross-spawn": "^7.0.0",
         "debug": "^4.1.1",
         "lodash": "^4.17.11",
         "minimist": "^1.2.0",
         "mkdirp": "^0.5.1",
         "progress": "2.0.3",
         "request": "2.88.2",
-        "tar-stream": "2.1.3",
+        "tar-stream": "2.1.4",
         "urijs": "^1.19.1",
-        "which": "^1.3.1",
+        "which": "^2.0.0",
         "yauzl": "^2.10.0"
       },
       "dependencies": {
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+        "async": {
+          "version": "3.2.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/async/-/async-3.2.0.tgz",
+          "integrity": "sha1-s6JoXF67ZB094C0WEALGD8n4VyA=",
+          "optional": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/which/-/which-2.0.2.tgz",
+          "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
           "optional": true,
           "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "isexe": "^2.0.0"
           }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-          "optional": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-          "optional": true
-        },
-        "path-key": {
-          "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-key/-/path-key-2.0.1.tgz",
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-          "optional": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
-          "optional": true
-        },
-        "shebang-command": {
-          "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shebang-command/-/shebang-command-1.2.0.tgz",
-          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-          "optional": true,
-          "requires": {
-            "shebang-regex": "^1.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
-          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-          "optional": true
         }
       }
     },
     "selenium-webdriver": {
       "version": "4.0.0-alpha.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/selenium-webdriver/-/selenium-webdriver-4.0.0-alpha.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/selenium-webdriver/-/selenium-webdriver-4.0.0-alpha.7.tgz",
       "integrity": "sha1-44edhFf9etjkQkCUt9wFQNmeZ5c=",
       "requires": {
         "jszip": "^3.2.2",
@@ -10729,7 +10966,7 @@
       "dependencies": {
         "tmp": {
           "version": "0.0.30",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tmp/-/tmp-0.0.30.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tmp/-/tmp-0.0.30.tgz",
           "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
           "requires": {
             "os-tmpdir": "~1.0.1"
@@ -10739,12 +10976,12 @@
     },
     "semver": {
       "version": "5.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-5.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/semver/-/semver-5.3.0.tgz",
       "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
     },
     "semver-diff": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver-diff/-/semver-diff-3.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/semver-diff/-/semver-diff-3.1.1.tgz",
       "integrity": "sha1-Bfd85Z8yXgDicGr9Z7tQbdscoys=",
       "requires": {
         "semver": "^6.3.0"
@@ -10752,14 +10989,14 @@
       "dependencies": {
         "semver": {
           "version": "6.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/semver/-/semver-6.3.0.tgz",
           "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0="
         }
       }
     },
     "send": {
       "version": "0.16.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/send/-/send-0.16.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/send/-/send-0.16.2.tgz",
       "integrity": "sha1-bsyh4PjBVtFBWXVZhI32RzCmu8E=",
       "requires": {
         "debug": "2.6.9",
@@ -10779,7 +11016,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
@@ -10787,7 +11024,7 @@
         },
         "http-errors": {
           "version": "1.6.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-errors/-/http-errors-1.6.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "requires": {
             "depd": "~1.1.2",
@@ -10798,37 +11035,42 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inherits/-/inherits-2.0.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "mime": {
           "version": "1.4.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mime/-/mime-1.4.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mime/-/mime-1.4.1.tgz",
           "integrity": "sha1-Eh+evEnjdm8xGnbh+hyAA8SwOqY="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "setprototypeof": {
           "version": "1.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/setprototypeof/-/setprototypeof-1.1.0.tgz",
           "integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY="
         },
         "statuses": {
           "version": "1.4.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/statuses/-/statuses-1.4.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/statuses/-/statuses-1.4.0.tgz",
           "integrity": "sha1-u3PURtonlhBu/MG2AaJT1sRr0Ic="
         }
       }
     },
     "serialize-javascript": {
-      "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-      "integrity": "sha1-tSXhI4SJpez8Qq+sw/6Z5mb0sao=",
+      "version": "5.0.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+      "integrity": "sha1-eIbshIBJpGJGepfT2Rjrsqr5NPQ=",
       "requires": {
         "randombytes": "^2.1.0"
       }
     },
     "serve-static": {
       "version": "1.14.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/serve-static/-/serve-static-1.14.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/serve-static/-/serve-static-1.14.1.tgz",
       "integrity": "sha1-Zm5jbcTwEPfvKZcKiKZ0MgiYsvk=",
       "requires": {
         "encodeurl": "~1.0.2",
@@ -10839,7 +11081,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
@@ -10847,19 +11089,19 @@
           "dependencies": {
             "ms": {
               "version": "2.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             }
           }
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.1.tgz",
           "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
         },
         "send": {
           "version": "0.17.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/send/-/send-0.17.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/send/-/send-0.17.1.tgz",
           "integrity": "sha1-wdiwWfeQD3Rm3Uk4vcROEd2zdsg=",
           "requires": {
             "debug": "2.6.9",
@@ -10881,27 +11123,27 @@
     },
     "server-destroy": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/server-destroy/-/server-destroy-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/server-destroy/-/server-destroy-1.0.1.tgz",
       "integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0="
     },
     "serviceworker-cache-polyfill": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/serviceworker-cache-polyfill/-/serviceworker-cache-polyfill-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/serviceworker-cache-polyfill/-/serviceworker-cache-polyfill-4.0.0.tgz",
       "integrity": "sha1-3hnuc77yGrPAdAo3sz22JGS6ves="
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-immediate-shim": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
     },
     "set-value": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/set-value/-/set-value-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/set-value/-/set-value-2.0.1.tgz",
       "integrity": "sha1-oY1AUw5vB95CKMfe/kInr4ytAFs=",
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -10912,7 +11154,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -10922,17 +11164,17 @@
     },
     "setprototypeof": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha1-fpWsskqpL1iF4KvvW6ExMw1K5oM="
     },
     "shady-css-parser": {
       "version": "0.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shady-css-parser/-/shady-css-parser-0.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/shady-css-parser/-/shady-css-parser-0.1.0.tgz",
       "integrity": "sha1-U03HnIyliExe2SpOWhPW2GO8pCg="
     },
     "shebang-command": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shebang-command/-/shebang-command-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
       "requires": {
         "shebang-regex": "^3.0.0"
@@ -10940,42 +11182,27 @@
     },
     "shebang-regex": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI="
     },
     "signal-exit": {
       "version": "3.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/signal-exit/-/signal-exit-3.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha1-oUEMLt2PB3sItOJTyOrPyvBXRhw="
     },
     "simple-git": {
-      "version": "2.20.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/simple-git/-/simple-git-2.20.1.tgz",
-      "integrity": "sha1-urP00IPtbhZVp8YquOiSDuyuhvY=",
+      "version": "2.21.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/simple-git/-/simple-git-2.21.0.tgz",
+      "integrity": "sha1-0l0/3GoTnNf4Dxl1Qab59unUy8g=",
       "requires": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
         "debug": "^4.1.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
-        }
       }
     },
     "simple-swizzle": {
       "version": "0.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "requires": {
         "is-arrayish": "^0.3.1"
@@ -10983,20 +11210,20 @@
       "dependencies": {
         "is-arrayish": {
           "version": "0.3.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-arrayish/-/is-arrayish-0.3.2.tgz",
           "integrity": "sha1-RXSirlb3qyBolvtDHq7tBm/fjwM="
         }
       }
     },
     "sinon": {
-      "version": "9.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sinon/-/sinon-9.0.3.tgz",
-      "integrity": "sha1-v/w+woyTYzLNKkGDNUe57tIB7P8=",
+      "version": "9.2.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sinon/-/sinon-9.2.0.tgz",
+      "integrity": "sha1-HTM5Z+MAI2Cfc0c1HrwNyWTA88k=",
       "requires": {
-        "@sinonjs/commons": "^1.7.2",
+        "@sinonjs/commons": "^1.8.1",
         "@sinonjs/fake-timers": "^6.0.1",
         "@sinonjs/formatio": "^5.0.1",
-        "@sinonjs/samsam": "^5.1.0",
+        "@sinonjs/samsam": "^5.2.0",
         "diff": "^4.0.2",
         "nise": "^4.0.4",
         "supports-color": "^7.1.0"
@@ -11004,12 +11231,12 @@
       "dependencies": {
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "requires": {
             "has-flag": "^4.0.0"
@@ -11019,17 +11246,17 @@
     },
     "sinon-chai": {
       "version": "2.14.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sinon-chai/-/sinon-chai-2.14.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sinon-chai/-/sinon-chai-2.14.0.tgz",
       "integrity": "sha1-2n3UzIPNaiYLZ8yg96n9riahIF0="
     },
     "slash": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/slash/-/slash-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/slash/-/slash-3.0.0.tgz",
       "integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ="
     },
     "slice-ansi": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/slice-ansi/-/slice-ansi-2.1.0.tgz",
       "integrity": "sha1-ys12k0YaY3pXiNkqfdT7oGjoFjY=",
       "requires": {
         "ansi-styles": "^3.2.0",
@@ -11039,14 +11266,14 @@
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         }
       }
     },
     "snapdragon": {
       "version": "0.8.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/snapdragon/-/snapdragon-0.8.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
       "requires": {
         "base": "^0.11.1",
@@ -11061,7 +11288,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
@@ -11069,7 +11296,7 @@
         },
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -11077,22 +11304,27 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
           }
         },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
     "snapdragon-node": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
       "requires": {
         "define-property": "^1.0.0",
@@ -11102,7 +11334,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
             "is-descriptor": "^1.0.0"
@@ -11110,7 +11342,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "requires": {
             "kind-of": "^6.0.0"
@@ -11118,7 +11350,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "requires": {
             "kind-of": "^6.0.0"
@@ -11126,7 +11358,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -11138,20 +11370,15 @@
     },
     "snapdragon-util": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
       "requires": {
         "kind-of": "^3.2.0"
       },
       "dependencies": {
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
-        },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -11161,7 +11388,7 @@
     },
     "socket.io": {
       "version": "2.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/socket.io/-/socket.io-2.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/socket.io/-/socket.io-2.3.0.tgz",
       "integrity": "sha1-zXYu1qT67KWbwfPiQ8CWkxHrc/s=",
       "requires": {
         "debug": "~4.1.0",
@@ -11174,27 +11401,22 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         }
       }
     },
     "socket.io-adapter": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/socket.io-adapter/-/socket.io-adapter-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/socket.io-adapter/-/socket.io-adapter-1.1.2.tgz",
       "integrity": "sha1-qz8Nb2a4/H/KOVmrWZH4IiF4m+k="
     },
     "socket.io-client": {
       "version": "2.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/socket.io-client/-/socket.io-client-2.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/socket.io-client/-/socket.io-client-2.3.0.tgz",
       "integrity": "sha1-FNW6LgC5vNFFrkQ6uWs/hsvMG7Q=",
       "requires": {
         "backo2": "1.0.2",
@@ -11213,14 +11435,19 @@
         "to-array": "0.1.4"
       },
       "dependencies": {
+        "base64-arraybuffer": {
+          "version": "0.1.5",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+          "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
+        },
         "component-emitter": {
           "version": "1.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.2.1.tgz",
           "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "requires": {
             "ms": "^2.1.1"
@@ -11228,27 +11455,27 @@
         },
         "isarray": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
         },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
-        },
         "socket.io-parser": {
-          "version": "3.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
-          "integrity": "sha1-K1KpalCf3zFEC6QP7WCUx9TxJi8=",
+          "version": "3.3.1",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/socket.io-parser/-/socket.io-parser-3.3.1.tgz",
+          "integrity": "sha1-8H2cjLP7kmM6qT522Y/TozRiMZk=",
           "requires": {
-            "component-emitter": "1.2.1",
+            "component-emitter": "~1.3.0",
             "debug": "~3.1.0",
             "isarray": "2.0.1"
           },
           "dependencies": {
+            "component-emitter": {
+              "version": "1.3.0",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.3.0.tgz",
+              "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A="
+            },
             "debug": {
               "version": "3.1.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-3.1.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-3.1.0.tgz",
               "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
               "requires": {
                 "ms": "2.0.0"
@@ -11256,7 +11483,7 @@
             },
             "ms": {
               "version": "2.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             }
           }
@@ -11265,7 +11492,7 @@
     },
     "socket.io-parser": {
       "version": "3.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/socket.io-parser/-/socket.io-parser-3.4.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/socket.io-parser/-/socket.io-parser-3.4.1.tgz",
       "integrity": "sha1-sGr4ODApdYN+qy3JgAN9okBU1ko=",
       "requires": {
         "component-emitter": "1.2.1",
@@ -11275,12 +11502,12 @@
       "dependencies": {
         "component-emitter": {
           "version": "1.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.2.1.tgz",
           "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "requires": {
             "ms": "^2.1.1"
@@ -11288,24 +11515,19 @@
         },
         "isarray": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         }
       }
     },
     "source-map": {
       "version": "0.6.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.6.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
     },
     "source-map-resolve": {
       "version": "0.5.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
       "integrity": "sha1-GQhmvs51U+H48mei7oLGBrVQmho=",
       "requires": {
         "atob": "^2.1.2",
@@ -11317,7 +11539,7 @@
     },
     "source-map-support": {
       "version": "0.5.19",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map-support/-/source-map-support-0.5.19.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map-support/-/source-map-support-0.5.19.tgz",
       "integrity": "sha1-qYti+G3K9PZzmWSMCFKRq56P7WE=",
       "requires": {
         "buffer-from": "^1.0.0",
@@ -11326,12 +11548,12 @@
     },
     "source-map-url": {
       "version": "0.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map-url/-/source-map-url-0.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
     },
     "spdx-correct": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/spdx-correct/-/spdx-correct-3.1.1.tgz",
       "integrity": "sha1-3s6BrJweZxPl99G28X1Gj6U9iak=",
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -11340,12 +11562,12 @@
     },
     "spdx-exceptions": {
       "version": "2.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
       "integrity": "sha1-PyjOGnegA3JoPq3kpDMYNSeiFj0="
     },
     "spdx-expression-parse": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha1-z3D1BILu/cmOPOCmgz5KU87rpnk=",
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -11353,13 +11575,13 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha1-NpS1gEVnpFjTyARYQqY1hjL2JlQ="
+      "version": "3.0.6",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz",
+      "integrity": "sha1-yAdXODwoq/cpZ0SZjLwQaui4VM4="
     },
     "spdy": {
       "version": "3.4.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdy/-/spdy-3.4.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/spdy/-/spdy-3.4.7.tgz",
       "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
       "requires": {
         "debug": "^2.6.8",
@@ -11372,17 +11594,22 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
     "spdy-transport": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdy-transport/-/spdy-transport-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/spdy-transport/-/spdy-transport-2.1.1.tgz",
       "integrity": "sha1-xUgV1zhYqt0GzmMAHn0l+mRBYjs=",
       "requires": {
         "debug": "^2.6.8",
@@ -11396,25 +11623,30 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
     "split": {
-      "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/split/-/split-1.0.1.tgz",
-      "integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
+      "version": "0.3.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
       "requires": {
         "through": "2"
       }
     },
     "split-string": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/split-string/-/split-string-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
       "requires": {
         "extend-shallow": "^3.0.0"
@@ -11422,12 +11654,12 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.16.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sshpk/-/sshpk-1.16.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
       "requires": {
         "asn1": "~0.2.3",
@@ -11443,17 +11675,17 @@
     },
     "stable": {
       "version": "0.1.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stable/-/stable-0.1.8.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/stable/-/stable-0.1.8.tgz",
       "integrity": "sha1-g26zyDgv4pNv6vVEYxAXzn1Ho88="
     },
     "stack-trace": {
       "version": "0.0.10",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stack-trace/-/stack-trace-0.0.10.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "stacky": {
       "version": "1.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stacky/-/stacky-1.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/stacky/-/stacky-1.3.1.tgz",
       "integrity": "sha1-PxF+UYe5pz0j+HbWnwXIWxGAShI=",
       "requires": {
         "chalk": "^1.1.1",
@@ -11462,12 +11694,12 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -11479,19 +11711,19 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
     "static-extend": {
       "version": "0.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/static-extend/-/static-extend-0.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "requires": {
         "define-property": "^0.2.5",
@@ -11500,7 +11732,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -11510,44 +11742,43 @@
     },
     "statuses": {
       "version": "1.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/statuses/-/statuses-1.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stealthy-require": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "stream": {
       "version": "0.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stream/-/stream-0.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/stream/-/stream-0.0.2.tgz",
       "integrity": "sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=",
       "requires": {
         "emitter-component": "^1.1.1"
       }
     },
     "stream-combiner": {
-      "version": "0.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stream-combiner/-/stream-combiner-0.2.2.tgz",
-      "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
+      "version": "0.0.4",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "requires": {
-        "duplexer": "~0.1.1",
-        "through": "~2.3.4"
+        "duplexer": "~0.1.1"
       }
     },
     "stream-shift": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stream-shift/-/stream-shift-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha1-1wiCgVWasneEJCebCHfaPDktWj0="
     },
     "streamsearch": {
       "version": "0.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/streamsearch/-/streamsearch-0.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
     "string-width": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
         "code-point-at": "^1.0.0",
@@ -11557,40 +11788,82 @@
     },
     "string.fromcodepoint": {
       "version": "0.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string.fromcodepoint/-/string.fromcodepoint-0.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string.fromcodepoint/-/string.fromcodepoint-0.2.1.tgz",
       "integrity": "sha1-jZeDM8C8klOPUPOD5IiPPlYZ1lM="
     },
     "string.prototype.codepointat": {
       "version": "0.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
       "integrity": "sha1-AErUTIr8cnUnsQjNRitNlxzUabw="
     },
     "string.prototype.trimend": {
-      "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
-      "integrity": "sha1-hYEqa4R6wAInD1gIFGBkyZX7aRM=",
+      "version": "1.0.2",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string.prototype.trimend/-/string.prototype.trimend-1.0.2.tgz",
+      "integrity": "sha1-bd2ah5a8cUtImjriIkaiCPN7+kY=",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "es-abstract": "^1.18.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0-next.1",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+          "integrity": "sha1-bjoKS9pxflAjqzuOkL7DYQjSLGg=",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-negative-zero": "^2.0.0",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
-      "integrity": "sha1-FK9tnzSwU/fPyJty+PLuFLkDmlQ=",
+      "version": "1.0.2",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string.prototype.trimstart/-/string.prototype.trimstart-1.0.2.tgz",
+      "integrity": "sha1-ItRdqBAVMJzQzdeXh+iRn8XGE+c=",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "es-abstract": "^1.18.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0-next.1",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+          "integrity": "sha1-bjoKS9pxflAjqzuOkL7DYQjSLGg=",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-negative-zero": "^2.0.0",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "string_decoder": {
       "version": "0.10.31",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-0.10.31.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -11598,7 +11871,7 @@
     },
     "strip-bom": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-bom/-/strip-bom-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "requires": {
         "is-utf8": "^0.2.0"
@@ -11606,7 +11879,7 @@
     },
     "strip-bom-stream": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
       "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
       "requires": {
         "first-chunk-stream": "^1.0.0",
@@ -11615,17 +11888,17 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-final-newline": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0="
     },
     "strip-indent": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-indent/-/strip-indent-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-indent/-/strip-indent-3.0.0.tgz",
       "integrity": "sha1-wy4c7pQLazQyx3G8LFS8znPNMAE=",
       "requires": {
         "min-indent": "^1.0.0"
@@ -11633,12 +11906,12 @@
     },
     "strip-json-comments": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY="
     },
     "supports-color": {
       "version": "5.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-5.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
       "requires": {
         "has-flag": "^3.0.0"
@@ -11646,7 +11919,7 @@
     },
     "supports-hyperlinks": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
       "integrity": "sha1-9mPfJSr183xdSbvX7u+p4Lnlnkc=",
       "requires": {
         "has-flag": "^4.0.0",
@@ -11655,12 +11928,12 @@
       "dependencies": {
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "requires": {
             "has-flag": "^4.0.0"
@@ -11670,7 +11943,7 @@
     },
     "svg-pathdata": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/svg-pathdata/-/svg-pathdata-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/svg-pathdata/-/svg-pathdata-1.0.4.tgz",
       "integrity": "sha1-emgTQqrH7/2NUq+6eZmRDJ2juVk=",
       "requires": {
         "readable-stream": "~2.0.4"
@@ -11678,17 +11951,17 @@
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
           "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
         },
         "readable-stream": {
           "version": "2.0.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-2.0.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -11703,7 +11976,7 @@
     },
     "svg2ttf": {
       "version": "4.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/svg2ttf/-/svg2ttf-4.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/svg2ttf/-/svg2ttf-4.3.0.tgz",
       "integrity": "sha1-QzRAx+kGL4/c7DytchzQiix+UeM=",
       "requires": {
         "argparse": "^1.0.6",
@@ -11716,7 +11989,7 @@
     },
     "svgicons2svgfont": {
       "version": "5.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/svgicons2svgfont/-/svgicons2svgfont-5.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/svgicons2svgfont/-/svgicons2svgfont-5.0.2.tgz",
       "integrity": "sha1-BRGCPGSRvhp9VDKS4pqK5ietBAY=",
       "requires": {
         "commander": "^2.9.0",
@@ -11730,12 +12003,12 @@
     },
     "svgpath": {
       "version": "2.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/svgpath/-/svgpath-2.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/svgpath/-/svgpath-2.3.0.tgz",
       "integrity": "sha1-78dnBd6ra9F3Tp8O0Di7ZhteTSM="
     },
     "sw-precache": {
       "version": "5.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sw-precache/-/sw-precache-5.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sw-precache/-/sw-precache-5.2.1.tgz",
       "integrity": "sha1-BhNPMZ7saPO5WDzppwNrHBGfcXk=",
       "requires": {
         "dom-urls": "^1.1.0",
@@ -11752,7 +12025,7 @@
       "dependencies": {
         "ansi-align": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-align/-/ansi-align-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-align/-/ansi-align-2.0.0.tgz",
           "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
           "requires": {
             "string-width": "^2.0.0"
@@ -11760,12 +12033,12 @@
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "boxen": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/boxen/-/boxen-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/boxen/-/boxen-1.3.0.tgz",
           "integrity": "sha1-VcbDmouljZxhrSLNh3Uy3rZlogs=",
           "requires": {
             "ansi-align": "^2.0.0",
@@ -11779,19 +12052,19 @@
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase/-/camelcase-4.1.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/camelcase/-/camelcase-4.1.0.tgz",
               "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
             }
           }
         },
         "camelcase": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase/-/camelcase-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/camelcase/-/camelcase-2.1.1.tgz",
           "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
         },
         "camelcase-keys": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "requires": {
             "camelcase": "^2.0.0",
@@ -11800,7 +12073,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -11810,17 +12083,17 @@
         },
         "ci-info": {
           "version": "1.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ci-info/-/ci-info-1.6.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ci-info/-/ci-info-1.6.0.tgz",
           "integrity": "sha1-LKINu5zrMtRSSmgzAzE/AwSx5Jc="
         },
         "cli-boxes": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-boxes/-/cli-boxes-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cli-boxes/-/cli-boxes-1.0.0.tgz",
           "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
         },
         "configstore": {
           "version": "3.1.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/configstore/-/configstore-3.1.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/configstore/-/configstore-3.1.5.tgz",
           "integrity": "sha1-6a8zH63BTavVRNPn523ERqCaUw8=",
           "requires": {
             "dot-prop": "^4.2.1",
@@ -11833,7 +12106,7 @@
         },
         "cross-spawn": {
           "version": "5.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "requires": {
             "lru-cache": "^4.0.1",
@@ -11843,12 +12116,12 @@
         },
         "crypto-random-string": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
           "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
         },
         "dot-prop": {
           "version": "4.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dot-prop/-/dot-prop-4.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/dot-prop/-/dot-prop-4.2.1.tgz",
           "integrity": "sha1-RYhBlKcfws2nHLtLzrOk3S9DO6Q=",
           "requires": {
             "is-obj": "^1.0.0"
@@ -11856,7 +12129,7 @@
         },
         "execa": {
           "version": "0.7.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/execa/-/execa-0.7.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "requires": {
             "cross-spawn": "^5.0.1",
@@ -11870,7 +12143,7 @@
         },
         "find-up": {
           "version": "1.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-up/-/find-up-1.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
             "path-exists": "^2.0.0",
@@ -11879,12 +12152,12 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
         },
         "global-dirs": {
           "version": "0.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/global-dirs/-/global-dirs-0.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/global-dirs/-/global-dirs-0.1.1.tgz",
           "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
           "requires": {
             "ini": "^1.3.4"
@@ -11892,7 +12165,7 @@
         },
         "got": {
           "version": "6.7.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/got/-/got-6.7.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/got/-/got-6.7.1.tgz",
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "requires": {
             "create-error-class": "^3.0.0",
@@ -11910,7 +12183,7 @@
         },
         "indent-string": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/indent-string/-/indent-string-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/indent-string/-/indent-string-2.1.0.tgz",
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "requires": {
             "repeating": "^2.0.0"
@@ -11918,7 +12191,7 @@
         },
         "is-ci": {
           "version": "1.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-ci/-/is-ci-1.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-ci/-/is-ci-1.2.1.tgz",
           "integrity": "sha1-43ecjuF/zPQoSI9uKBGH8uYyhBw=",
           "requires": {
             "ci-info": "^1.5.0"
@@ -11926,12 +12199,12 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "is-installed-globally": {
           "version": "0.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
           "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
           "requires": {
             "global-dirs": "^0.1.0",
@@ -11940,17 +12213,17 @@
         },
         "is-npm": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-npm/-/is-npm-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-npm/-/is-npm-1.0.0.tgz",
           "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
         },
         "is-obj": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-obj/-/is-obj-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-obj/-/is-obj-1.0.1.tgz",
           "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
         },
         "is-path-inside": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-path-inside/-/is-path-inside-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-path-inside/-/is-path-inside-1.0.1.tgz",
           "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
           "requires": {
             "path-is-inside": "^1.0.1"
@@ -11958,7 +12231,7 @@
         },
         "latest-version": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/latest-version/-/latest-version-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/latest-version/-/latest-version-3.1.0.tgz",
           "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
           "requires": {
             "package-json": "^4.0.0"
@@ -11966,7 +12239,7 @@
         },
         "lru-cache": {
           "version": "4.1.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lru-cache/-/lru-cache-4.1.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lru-cache/-/lru-cache-4.1.5.tgz",
           "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
           "requires": {
             "pseudomap": "^1.0.2",
@@ -11975,7 +12248,7 @@
         },
         "make-dir": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/make-dir/-/make-dir-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/make-dir/-/make-dir-1.3.0.tgz",
           "integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
           "requires": {
             "pify": "^3.0.0"
@@ -11983,19 +12256,19 @@
           "dependencies": {
             "pify": {
               "version": "3.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pify/-/pify-3.0.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pify/-/pify-3.0.0.tgz",
               "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
             }
           }
         },
         "map-obj": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-obj/-/map-obj-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/map-obj/-/map-obj-1.0.1.tgz",
           "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
         },
         "meow": {
           "version": "3.7.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/meow/-/meow-3.7.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/meow/-/meow-3.7.0.tgz",
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "requires": {
             "camelcase-keys": "^2.0.0",
@@ -12012,7 +12285,7 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
           "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "requires": {
             "path-key": "^2.0.0"
@@ -12020,7 +12293,7 @@
         },
         "package-json": {
           "version": "4.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/package-json/-/package-json-4.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/package-json/-/package-json-4.0.1.tgz",
           "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
           "requires": {
             "got": "^6.7.1",
@@ -12031,7 +12304,7 @@
         },
         "path-exists": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-exists/-/path-exists-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
             "pinkie-promise": "^2.0.0"
@@ -12039,12 +12312,12 @@
         },
         "path-key": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-key/-/path-key-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-key/-/path-key-2.0.1.tgz",
           "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
         },
         "path-type": {
           "version": "1.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-type/-/path-type-1.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -12054,12 +12327,12 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         },
         "read-pkg": {
           "version": "1.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/read-pkg/-/read-pkg-1.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
             "load-json-file": "^1.0.0",
@@ -12069,7 +12342,7 @@
         },
         "read-pkg-up": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
             "find-up": "^1.0.0",
@@ -12078,7 +12351,7 @@
         },
         "redent": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/redent/-/redent-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/redent/-/redent-1.0.0.tgz",
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "requires": {
             "indent-string": "^2.1.0",
@@ -12087,7 +12360,7 @@
         },
         "registry-auth-token": {
           "version": "3.4.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
           "integrity": "sha1-10RoFUM/XV7WQxzV3KIQSPZrOX4=",
           "requires": {
             "rc": "^1.1.6",
@@ -12096,7 +12369,7 @@
         },
         "registry-url": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/registry-url/-/registry-url-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/registry-url/-/registry-url-3.1.0.tgz",
           "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
           "requires": {
             "rc": "^1.0.1"
@@ -12104,7 +12377,7 @@
         },
         "semver-diff": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver-diff/-/semver-diff-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/semver-diff/-/semver-diff-2.1.0.tgz",
           "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
           "requires": {
             "semver": "^5.0.3"
@@ -12112,7 +12385,7 @@
         },
         "shebang-command": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shebang-command/-/shebang-command-1.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/shebang-command/-/shebang-command-1.2.0.tgz",
           "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -12120,12 +12393,12 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
           "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -12134,7 +12407,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
             "ansi-regex": "^3.0.0"
@@ -12142,7 +12415,7 @@
         },
         "strip-indent": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-indent/-/strip-indent-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-indent/-/strip-indent-1.0.1.tgz",
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "requires": {
             "get-stdin": "^4.0.1"
@@ -12150,7 +12423,7 @@
         },
         "term-size": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/term-size/-/term-size-1.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/term-size/-/term-size-1.2.0.tgz",
           "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
           "requires": {
             "execa": "^0.7.0"
@@ -12158,17 +12431,17 @@
         },
         "timed-out": {
           "version": "4.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/timed-out/-/timed-out-4.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/timed-out/-/timed-out-4.0.1.tgz",
           "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
         },
         "trim-newlines": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/trim-newlines/-/trim-newlines-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/trim-newlines/-/trim-newlines-1.0.0.tgz",
           "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
         },
         "unique-string": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unique-string/-/unique-string-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unique-string/-/unique-string-1.0.0.tgz",
           "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
           "requires": {
             "crypto-random-string": "^1.0.0"
@@ -12176,12 +12449,12 @@
         },
         "unzip-response": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unzip-response/-/unzip-response-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unzip-response/-/unzip-response-2.0.1.tgz",
           "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
         },
         "update-notifier": {
           "version": "2.5.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/update-notifier/-/update-notifier-2.5.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/update-notifier/-/update-notifier-2.5.0.tgz",
           "integrity": "sha1-0HRFk+E/Fh5AassdlAi3LK0Ir/Y=",
           "requires": {
             "boxen": "^1.2.1",
@@ -12198,7 +12471,7 @@
         },
         "widest-line": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/widest-line/-/widest-line-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/widest-line/-/widest-line-2.0.1.tgz",
           "integrity": "sha1-dDh2RzDsfvQ4HOTfgvuYpTFCo/w=",
           "requires": {
             "string-width": "^2.1.1"
@@ -12206,7 +12479,7 @@
         },
         "write-file-atomic": {
           "version": "2.4.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
           "integrity": "sha1-H9Lprh3z51uNjDZ0Q8aS1MqB9IE=",
           "requires": {
             "graceful-fs": "^4.1.11",
@@ -12216,19 +12489,19 @@
         },
         "xdg-basedir": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
           "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yallist/-/yallist-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
         }
       }
     },
     "sw-toolbox": {
       "version": "3.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sw-toolbox/-/sw-toolbox-3.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sw-toolbox/-/sw-toolbox-3.6.0.tgz",
       "integrity": "sha1-Jt8dHHA0hljk3qKIQxkUm3sxg7U=",
       "requires": {
         "path-to-regexp": "^1.0.1",
@@ -12237,7 +12510,7 @@
       "dependencies": {
         "path-to-regexp": {
           "version": "1.8.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
           "integrity": "sha1-iHs7qdhDk+h6CgufTLdWGYtTVIo=",
           "requires": {
             "isarray": "0.0.1"
@@ -12247,22 +12520,22 @@
     },
     "swipe-detect": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/swipe-detect/-/swipe-detect-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/swipe-detect/-/swipe-detect-1.0.1.tgz",
       "integrity": "sha1-AtoVzoVqqdtRcj4acf2+jizoRTg="
     },
     "symbol-observable": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/symbol-observable/-/symbol-observable-1.2.0.tgz",
       "integrity": "sha1-wiaIrtTqs83C3+rLtWFmBWCgCAQ="
     },
     "symbol-tree": {
       "version": "3.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha1-QwY30ki6d+B4iDlR+5qg7tfGP6I="
     },
     "table": {
       "version": "5.4.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/table/-/table-5.4.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/table/-/table-5.4.6.tgz",
       "integrity": "sha1-EpLRlQDOP4YFOwXw6Ofko7shB54=",
       "requires": {
         "ajv": "^6.10.2",
@@ -12273,17 +12546,17 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "requires": {
             "emoji-regex": "^7.0.1",
@@ -12293,7 +12566,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -12303,7 +12576,7 @@
     },
     "table-layout": {
       "version": "0.4.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/table-layout/-/table-layout-0.4.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/table-layout/-/table-layout-0.4.5.tgz",
       "integrity": "sha1-2QbeaiX6CcDJDR0I7Ngz7O3Lc3g=",
       "requires": {
         "array-back": "^2.0.0",
@@ -12315,7 +12588,7 @@
       "dependencies": {
         "array-back": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-back/-/array-back-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-back/-/array-back-2.0.0.tgz",
           "integrity": "sha1-aHdHHVHsycm/phNvtsfV/ml0gCI=",
           "requires": {
             "typical": "^2.6.1"
@@ -12323,14 +12596,14 @@
         },
         "typical": {
           "version": "2.6.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typical/-/typical-2.6.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/typical/-/typical-2.6.1.tgz",
           "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
         }
       }
     },
     "tar": {
       "version": "2.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tar/-/tar-2.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tar/-/tar-2.2.2.tgz",
       "integrity": "sha1-DKiEhWLHKZuLRG/2pNYM27I+3EA=",
       "requires": {
         "block-stream": "*",
@@ -12339,11 +12612,11 @@
       }
     },
     "tar-stream": {
-      "version": "2.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tar-stream/-/tar-stream-2.1.3.tgz",
-      "integrity": "sha1-HiAiVZIht4ZhYWYPEYJV4g+nnkE=",
+      "version": "2.1.4",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tar-stream/-/tar-stream-2.1.4.tgz",
+      "integrity": "sha1-xPsaEesNopuJOlslR2OXui0FO/o=",
       "requires": {
-        "bl": "^4.0.1",
+        "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
         "fs-constants": "^1.0.0",
         "inherits": "^2.0.3",
@@ -12352,7 +12625,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.6.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
           "requires": {
             "inherits": "^2.0.3",
@@ -12362,12 +12635,12 @@
         },
         "safe-buffer": {
           "version": "5.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY="
         },
         "string_decoder": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.3.0.tgz",
           "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
           "requires": {
             "safe-buffer": "~5.2.0"
@@ -12377,7 +12650,7 @@
     },
     "tcp-port-used": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tcp-port-used/-/tcp-port-used-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tcp-port-used/-/tcp-port-used-1.0.1.tgz",
       "integrity": "sha1-RgYQeOLTjHOXmiwsErWmdOZonXA=",
       "requires": {
         "debug": "4.1.0",
@@ -12386,22 +12659,17 @@
       "dependencies": {
         "debug": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.0.tgz",
           "integrity": "sha1-NzaHv/pnizixzZH4YbY4UANd3Ic=",
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         }
       }
     },
     "temp": {
       "version": "0.8.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/temp/-/temp-0.8.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/temp/-/temp-0.8.4.tgz",
       "integrity": "sha1-jJejOkdwBy4KBfkZOWx2ZafdWfI=",
       "optional": true,
       "requires": {
@@ -12410,7 +12678,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.6.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rimraf/-/rimraf-2.6.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/rimraf/-/rimraf-2.6.3.tgz",
           "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
           "optional": true,
           "requires": {
@@ -12419,14 +12687,32 @@
         }
       }
     },
+    "temp-fs": {
+      "version": "0.9.9",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/temp-fs/-/temp-fs-0.9.9.tgz",
+      "integrity": "sha1-gHFzBDeHByDpQxUy/igUNk+IA9c=",
+      "requires": {
+        "rimraf": "~2.5.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.5.4",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/rimraf/-/rimraf-2.5.4.tgz",
+          "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        }
+      }
+    },
     "term-size": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/term-size/-/term-size-2.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/term-size/-/term-size-2.2.0.tgz",
       "integrity": "sha1-Hxat7f6b3BiADhd2ghc0CG/MZ1M="
     },
     "terminal-link": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/terminal-link/-/terminal-link-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/terminal-link/-/terminal-link-2.1.1.tgz",
       "integrity": "sha1-FKZKJ6s8Dfkz6lRvulXy0HjtyZQ=",
       "requires": {
         "ansi-escapes": "^4.2.1",
@@ -12435,7 +12721,7 @@
     },
     "ternary-stream": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ternary-stream/-/ternary-stream-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ternary-stream/-/ternary-stream-2.1.1.tgz",
       "integrity": "sha1-StZLmGaNeWoIWvLEk4haQ1qKi/w=",
       "requires": {
         "duplexify": "^3.5.0",
@@ -12446,7 +12732,7 @@
       "dependencies": {
         "merge-stream": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/merge-stream/-/merge-stream-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/merge-stream/-/merge-stream-1.0.1.tgz",
           "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
           "requires": {
             "readable-stream": "^2.0.1"
@@ -12455,38 +12741,45 @@
       }
     },
     "terser": {
-      "version": "5.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/terser/-/terser-5.3.1.tgz",
-      "integrity": "sha1-9Q/iCrSLFSNP6b3YaxAUitX8p4c=",
+      "version": "5.3.8",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/terser/-/terser-5.3.8.tgz",
+      "integrity": "sha1-mRrouiGj2ZBXm1SqmvEVhhl6dd0=",
       "requires": {
         "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
+        "source-map": "~0.7.2",
+        "source-map-support": "~0.5.19"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha1-UwL4FpAxc1ImVECS5kmB91F1A4M="
+        }
       }
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
     },
     "text-hex": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/text-hex/-/text-hex-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/text-hex/-/text-hex-1.0.0.tgz",
       "integrity": "sha1-adycGxdEbueakr9biEu0uRJ1BvU="
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "textfit": {
       "version": "2.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/textfit/-/textfit-2.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/textfit/-/textfit-2.4.0.tgz",
       "integrity": "sha1-gMuoAGv7nD2dVSc5JXlXvdqVx5w="
     },
     "thenify": {
       "version": "3.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/thenify/-/thenify-3.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha1-iTLmhqQGYDigFt2eLKRq3Zg4qV8=",
       "requires": {
         "any-promise": "^1.0.0"
@@ -12494,7 +12787,7 @@
     },
     "thenify-all": {
       "version": "1.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/thenify-all/-/thenify-all-1.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
       "requires": {
         "thenify": ">= 3.1.0 < 4"
@@ -12502,12 +12795,12 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through/-/through-2.3.8.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "2.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through2/-/through2-2.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/through2/-/through2-2.0.5.tgz",
       "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
       "requires": {
         "readable-stream": "~2.3.6",
@@ -12516,7 +12809,7 @@
     },
     "through2-filter": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through2-filter/-/through2-filter-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/through2-filter/-/through2-filter-2.0.0.tgz",
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
       "requires": {
         "through2": "~2.0.0",
@@ -12525,22 +12818,22 @@
     },
     "timed-out": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/timed-out/-/timed-out-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/timed-out/-/timed-out-2.0.0.tgz",
       "integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo="
     },
     "tiny-emitter": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha1-HRpW7fxRxD6GPLtTgqcjMONVVCM="
     },
     "tinymce": {
-      "version": "5.4.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tinymce/-/tinymce-5.4.2.tgz",
-      "integrity": "sha1-od9BfqfoVpfCkyJp9/k/vvMNRQI="
+      "version": "5.5.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tinymce/-/tinymce-5.5.1.tgz",
+      "integrity": "sha1-TyTKbntpijx0GKOe8PPWE/SnA6Q="
     },
     "tmp": {
       "version": "0.0.33",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tmp/-/tmp-0.0.33.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
       "requires": {
         "os-tmpdir": "~1.0.2"
@@ -12548,7 +12841,7 @@
     },
     "to-absolute-glob": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
       "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
       "requires": {
         "extend-shallow": "^2.0.1"
@@ -12556,7 +12849,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -12566,30 +12859,25 @@
     },
     "to-array": {
       "version": "0.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-array/-/to-array-0.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-array/-/to-array-0.1.4.tgz",
       "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
     },
     "to-fast-properties": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-object-path": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-object-path/-/to-object-path-0.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "requires": {
         "kind-of": "^3.0.2"
       },
       "dependencies": {
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
-        },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -12599,12 +12887,12 @@
     },
     "to-readable-stream": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-readable-stream/-/to-readable-stream-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-readable-stream/-/to-readable-stream-2.1.0.tgz",
       "integrity": "sha1-gogDFhIb6mYs3CJq2zCt21DLBug="
     },
     "to-regex": {
       "version": "3.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-regex/-/to-regex-3.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
       "requires": {
         "define-property": "^2.0.2",
@@ -12615,7 +12903,7 @@
     },
     "to-regex-range": {
       "version": "5.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
       "requires": {
         "is-number": "^7.0.0"
@@ -12623,12 +12911,12 @@
     },
     "toidentifier": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/toidentifier/-/toidentifier-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha1-fhvjRw8ed5SLxD2Uo8j013UrpVM="
     },
     "tooltip.js": {
       "version": "1.3.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tooltip.js/-/tooltip.js-1.3.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tooltip.js/-/tooltip.js-1.3.3.tgz",
       "integrity": "sha1-KtDXe7Z3anbhF+rAr808fTojcSE=",
       "requires": {
         "popper.js": "^1.0.2"
@@ -12636,7 +12924,7 @@
     },
     "tough-cookie": {
       "version": "2.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
       "requires": {
         "psl": "^1.1.28",
@@ -12645,7 +12933,7 @@
     },
     "tr46": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tr46/-/tr46-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "requires": {
         "punycode": "^2.1.0"
@@ -12653,37 +12941,37 @@
     },
     "trim-newlines": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/trim-newlines/-/trim-newlines-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/trim-newlines/-/trim-newlines-3.0.0.tgz",
       "integrity": "sha1-eXJjBKaomKqDc0JymNVMLuixyzA="
     },
     "trim-right": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/trim-right/-/trim-right-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "triple-beam": {
       "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/triple-beam/-/triple-beam-1.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/triple-beam/-/triple-beam-1.3.0.tgz",
       "integrity": "sha1-pZUhTHKY24M57u7gg+TRC9jLjdk="
     },
     "try-catch": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/try-catch/-/try-catch-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/try-catch/-/try-catch-3.0.0.tgz",
       "integrity": "sha1-eZbYuJiV4uiuYsvb60/hdHD4Exs="
     },
     "try-to-catch": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/try-to-catch/-/try-to-catch-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/try-to-catch/-/try-to-catch-3.0.0.tgz",
       "integrity": "sha1-oZA7RNE9USTFTRSkYdIuwfUuoUs="
     },
     "tslib": {
-      "version": "1.13.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha1-yIHhPMcBWJTtkUhi0nZDb6mkcEM="
+      "version": "1.14.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA="
     },
     "ttf2eot": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ttf2eot/-/ttf2eot-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ttf2eot/-/ttf2eot-2.0.0.tgz",
       "integrity": "sha1-jmM3pYWr0WCKDISVirSDzmn2ZUs=",
       "requires": {
         "argparse": "^1.0.6",
@@ -12692,7 +12980,7 @@
     },
     "ttf2woff": {
       "version": "2.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ttf2woff/-/ttf2woff-2.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ttf2woff/-/ttf2woff-2.0.2.tgz",
       "integrity": "sha1-CafO5Zq9PBUoK1fthKx8d3B0nx8=",
       "requires": {
         "argparse": "^1.0.6",
@@ -12702,7 +12990,7 @@
     },
     "ttf2woff2": {
       "version": "2.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ttf2woff2/-/ttf2woff2-2.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ttf2woff2/-/ttf2woff2-2.0.3.tgz",
       "integrity": "sha1-XgIK/m5kMofzrXaHq+0g/mVOsyk=",
       "requires": {
         "bindings": "^1.2.1",
@@ -12713,7 +13001,7 @@
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -12721,12 +13009,12 @@
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
       "version": "0.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-check/-/type-check-0.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha1-B7ggO/pwVsBlcFDjzNLDdzC6uPE=",
       "requires": {
         "prelude-ls": "^1.2.1"
@@ -12734,17 +13022,17 @@
     },
     "type-detect": {
       "version": "4.0.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-detect/-/type-detect-4.0.8.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw="
     },
     "type-fest": {
       "version": "0.8.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.8.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha1-CeJJ696FHTseSNJ8EFREZn8XuD0="
     },
     "type-is": {
       "version": "1.6.18",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-is/-/type-is-1.6.18.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha1-TlUs0F3wlGfcvE73Od6J8s83wTE=",
       "requires": {
         "media-typer": "0.3.0",
@@ -12753,12 +13041,12 @@
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typedarray/-/typedarray-0.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha1-qX7nqf9CaRufeD/xvFES/j/KkIA=",
       "requires": {
         "is-typedarray": "^1.0.0"
@@ -12766,37 +13054,37 @@
     },
     "typical": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typical/-/typical-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/typical/-/typical-4.0.0.tgz",
       "integrity": "sha1-y+r/O5164eK7+vWk5vEezP3pT8Q="
     },
     "ua-parser-js": {
       "version": "0.7.22",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
       "integrity": "sha1-lg32Cl+RHqjxyBjzdHuZxuF36uM="
     },
     "uglify-js": {
-      "version": "3.10.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/uglify-js/-/uglify-js-3.10.4.tgz",
-      "integrity": "sha1-3WgPVoe8DXqTsUo0gtFttuuiv7s="
+      "version": "3.11.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/uglify-js/-/uglify-js-3.11.3.tgz",
+      "integrity": "sha1-svjIeCY0TwkbpIxBfEmdbLpdV4Y="
     },
     "underscore": {
       "version": "1.11.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/underscore/-/underscore-1.11.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/underscore/-/underscore-1.11.0.tgz",
       "integrity": "sha1-3XwjoZXbNCZxhgRGSYcP8bq1kp4="
     },
     "unescape-html": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unescape-html/-/unescape-html-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unescape-html/-/unescape-html-1.1.0.tgz",
       "integrity": "sha1-0kcF6C8MnmKoetpi882WMD19Kjw="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
       "integrity": "sha1-JhmADEyCWADv3YNDr33Zkzy+KBg="
     },
     "unicode-match-property-ecmascript": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
       "integrity": "sha1-jtKjJWmWG86SJ9Cc0/+7j+1fAgw=",
       "requires": {
         "unicode-canonical-property-names-ecmascript": "^1.0.4",
@@ -12805,17 +13093,17 @@
     },
     "unicode-match-property-value-ecmascript": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
       "integrity": "sha1-DZH2AO7rMJaqlisdb8iIduZOpTE="
     },
     "unicode-property-aliases-ecmascript": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
       "integrity": "sha1-3Vepn2IHvt/0Yoq++5TFDblByPQ="
     },
     "union": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/union/-/union-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/union/-/union-0.5.0.tgz",
       "integrity": "sha1-ssEb6E9gU4U3uEbtuboma6AJAHU=",
       "requires": {
         "qs": "^6.4.0"
@@ -12823,7 +13111,7 @@
     },
     "union-value": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/union-value/-/union-value-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/union-value/-/union-value-1.0.1.tgz",
       "integrity": "sha1-C2/nuDWuzaYcbqTU8CwUIh4QmEc=",
       "requires": {
         "arr-union": "^3.1.0",
@@ -12834,7 +13122,7 @@
     },
     "unique-stream": {
       "version": "2.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unique-stream/-/unique-stream-2.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unique-stream/-/unique-stream-2.3.1.tgz",
       "integrity": "sha1-xl0RDppK35psWUiygFPZqNBMvqw=",
       "requires": {
         "json-stable-stringify-without-jsonify": "^1.0.1",
@@ -12843,7 +13131,7 @@
       "dependencies": {
         "through2-filter": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through2-filter/-/through2-filter-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/through2-filter/-/through2-filter-3.0.0.tgz",
           "integrity": "sha1-cA54bfI2fCyIzYqlvkz5weeDElQ=",
           "requires": {
             "through2": "~2.0.0",
@@ -12854,7 +13142,7 @@
     },
     "unique-string": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unique-string/-/unique-string-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unique-string/-/unique-string-2.0.0.tgz",
       "integrity": "sha1-OcZFH4GvsnSd4rIz4/fF6IQ72J0=",
       "requires": {
         "crypto-random-string": "^2.0.0"
@@ -12862,12 +13150,12 @@
     },
     "unpipe": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "unset-value": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unset-value/-/unset-value-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "requires": {
         "has-value": "^0.3.1",
@@ -12876,7 +13164,7 @@
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-value/-/has-value-0.3.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "requires": {
             "get-value": "^2.0.3",
@@ -12886,7 +13174,7 @@
           "dependencies": {
             "isobject": {
               "version": "2.1.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isobject/-/isobject-2.1.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
               "requires": {
                 "isarray": "1.0.0"
@@ -12896,19 +13184,19 @@
         },
         "has-values": {
           "version": "0.1.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-values/-/has-values-0.1.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         }
       }
     },
     "untildify": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/untildify/-/untildify-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/untildify/-/untildify-2.1.0.tgz",
       "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
       "requires": {
         "os-homedir": "^1.0.0"
@@ -12916,13 +13204,13 @@
     },
     "unzip-response": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unzip-response/-/unzip-response-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unzip-response/-/unzip-response-1.0.2.tgz",
       "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
     },
     "update-notifier": {
-      "version": "4.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/update-notifier/-/update-notifier-4.1.1.tgz",
-      "integrity": "sha1-iV/IViu+ZmF5UA+fLOusTyYyN0Y=",
+      "version": "4.1.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/update-notifier/-/update-notifier-4.1.3.tgz",
+      "integrity": "sha1-vobuE+jOSPtQBD/3IFe1vVmOHqM=",
       "requires": {
         "boxen": "^4.2.0",
         "chalk": "^3.0.0",
@@ -12940,17 +13228,16 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha1-kK51xCTQCNJiTFvynq0xd+v881k=",
+          "version": "4.3.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
         "chalk": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-3.0.0.tgz",
           "integrity": "sha1-P3PCv1JlkfV0zEksUeJFY0n4ROQ=",
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -12959,7 +13246,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "requires": {
             "color-name": "~1.1.4"
@@ -12967,17 +13254,17 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "requires": {
             "has-flag": "^4.0.0"
@@ -12987,12 +13274,12 @@
     },
     "upper-case": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/upper-case/-/upper-case-1.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/upper-case/-/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
     },
     "uri-js": {
       "version": "4.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/uri-js/-/uri-js-4.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/uri-js/-/uri-js-4.4.0.tgz",
       "integrity": "sha1-qnFCYd55PoqCNHp7zJznTobyhgI=",
       "requires": {
         "punycode": "^2.1.0"
@@ -13000,22 +13287,22 @@
     },
     "urijs": {
       "version": "1.19.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/urijs/-/urijs-1.19.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/urijs/-/urijs-1.19.2.tgz",
       "integrity": "sha1-+b4J8AxMUTS3yzz0dcHdOUUmJlo="
     },
     "urix": {
       "version": "0.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/urix/-/urix-0.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
     },
     "url-join": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/url-join/-/url-join-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/url-join/-/url-join-1.1.0.tgz",
       "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg="
     },
     "url-parse-lax": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "requires": {
         "prepend-http": "^1.0.1"
@@ -13023,12 +13310,12 @@
     },
     "use": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/use/-/use-3.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/use/-/use-3.1.1.tgz",
       "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8="
     },
     "util": {
       "version": "0.12.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/util/-/util-0.12.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/util/-/util-0.12.3.tgz",
       "integrity": "sha1-lxuwKS0swMiS2rfGpdN8K+xweIg=",
       "requires": {
         "inherits": "^2.0.3",
@@ -13041,32 +13328,32 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/utils-merge/-/utils-merge-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
       "version": "3.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/uuid/-/uuid-3.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4="
     },
     "v8-compile-cache": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
       "integrity": "sha1-VLw83UMxe8qR413K8wWxpyN950U="
     },
     "vali-date": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vali-date/-/vali-date-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vali-date/-/vali-date-1.0.0.tgz",
       "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
       "requires": {
         "spdx-correct": "^3.0.0",
@@ -13075,7 +13362,7 @@
     },
     "validate-npm-package-name": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
       "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
       "requires": {
         "builtins": "^1.0.3"
@@ -13083,17 +13370,17 @@
     },
     "validate.js": {
       "version": "0.12.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/validate.js/-/validate.js-0.12.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/validate.js/-/validate.js-0.12.0.tgz",
       "integrity": "sha1-F/mJ43wZLqL4Jrvxm/Tpfm5L5o8="
     },
     "vargs": {
       "version": "0.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vargs/-/vargs-0.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vargs/-/vargs-0.1.0.tgz",
       "integrity": "sha1-a2GE2mUgzDIEzhtAfKwm2SYJ6/8="
     },
     "varstream": {
       "version": "0.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/varstream/-/varstream-0.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/varstream/-/varstream-0.3.2.tgz",
       "integrity": "sha1-GKxklHZfP/GjWtmkvgU77BiKXeE=",
       "requires": {
         "readable-stream": "^1.0.33"
@@ -13101,7 +13388,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -13114,17 +13401,17 @@
     },
     "vary": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vary/-/vary-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "vee-validate": {
-      "version": "3.4.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vee-validate/-/vee-validate-3.4.0.tgz",
-      "integrity": "sha1-3N781F1DgjyLJqzu5V8GfvVsqAA="
+      "version": "3.4.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vee-validate/-/vee-validate-3.4.3.tgz",
+      "integrity": "sha1-O4WtsbFdrc61Jdwn2JQTamNTu88="
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -13134,7 +13421,7 @@
     },
     "vinyl": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vinyl/-/vinyl-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vinyl/-/vinyl-1.2.0.tgz",
       "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
       "requires": {
         "clone": "^1.0.0",
@@ -13144,14 +13431,14 @@
       "dependencies": {
         "clone": {
           "version": "1.0.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clone/-/clone-1.0.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/clone/-/clone-1.0.4.tgz",
           "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
         }
       }
     },
     "vinyl-fs": {
       "version": "2.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
       "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
       "requires": {
         "duplexify": "^3.2.0",
@@ -13175,7 +13462,7 @@
       "dependencies": {
         "merge-stream": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/merge-stream/-/merge-stream-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/merge-stream/-/merge-stream-1.0.1.tgz",
           "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
           "requires": {
             "readable-stream": "^2.0.1"
@@ -13185,7 +13472,7 @@
     },
     "vl-mapactions": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-mapactions/-/vl-mapactions-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-mapactions/-/vl-mapactions-2.1.0.tgz",
       "integrity": "sha1-pO27YTCh9qOz1EzNJ04eQvfKOig=",
       "requires": {
         "bootstrap-sass": "3.3.4",
@@ -13195,7 +13482,7 @@
     },
     "vl-ui-accordion": {
       "version": "3.0.9",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-accordion/-/vl-ui-accordion-3.0.9.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-accordion/-/vl-ui-accordion-3.0.9.tgz",
       "integrity": "sha1-/YAa0LU1v723SjWzKim5vyZ+rwg=",
       "requires": {
         "@govflanders/vl-ui-accordion": "^3.11.5",
@@ -13204,7 +13491,7 @@
     },
     "vl-ui-action-group": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-action-group/-/vl-ui-action-group-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-action-group/-/vl-ui-action-group-3.1.0.tgz",
       "integrity": "sha1-/4Eo5aCkEljASy0KK9QoihLrMEQ=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13212,7 +13499,7 @@
     },
     "vl-ui-alert": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-alert/-/vl-ui-alert-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-alert/-/vl-ui-alert-4.0.0.tgz",
       "integrity": "sha1-SFt/Wj50Uovf5IoMspXqnPywbYo=",
       "requires": {
         "vl-ui-core": "^6.0.0",
@@ -13221,7 +13508,7 @@
     },
     "vl-ui-body": {
       "version": "1.0.5",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-body/-/vl-ui-body-1.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-body/-/vl-ui-body-1.0.5.tgz",
       "integrity": "sha1-xx5EnkGShxYIkkbxZgXLYytcilo=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13229,7 +13516,7 @@
     },
     "vl-ui-breadcrumb": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-breadcrumb/-/vl-ui-breadcrumb-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-breadcrumb/-/vl-ui-breadcrumb-1.0.0.tgz",
       "integrity": "sha1-wLFf3kcPJKMoNC9qhyvW9CZ+1VA=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13237,7 +13524,7 @@
     },
     "vl-ui-button": {
       "version": "5.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-button/-/vl-ui-button-5.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-button/-/vl-ui-button-5.0.6.tgz",
       "integrity": "sha1-IpPb7DnoomMEImAFgK6VYXMeCP4=",
       "requires": {
         "vl-ui-core": "^6.0.0",
@@ -13246,7 +13533,7 @@
     },
     "vl-ui-checkbox": {
       "version": "3.2.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-checkbox/-/vl-ui-checkbox-3.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-checkbox/-/vl-ui-checkbox-3.2.1.tgz",
       "integrity": "sha1-Gtnv7hgqGpzCQfXIuH0K56nGe7s=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13254,7 +13541,7 @@
     },
     "vl-ui-code-preview": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-code-preview/-/vl-ui-code-preview-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-code-preview/-/vl-ui-code-preview-1.0.1.tgz",
       "integrity": "sha1-MGOaJNjTn33UoB3YNL5quWK9774=",
       "requires": {
         "@govflanders/vl-ui-code-preview": "^3.11.5",
@@ -13265,16 +13552,16 @@
     },
     "vl-ui-content-header": {
       "version": "3.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-content-header/-/vl-ui-content-header-3.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-content-header/-/vl-ui-content-header-3.0.5.tgz",
       "integrity": "sha1-cmbOP7dJfawPTBgqhNMEDW0ZnTE=",
       "requires": {
         "vl-ui-core": "^6.0.0"
       }
     },
     "vl-ui-cookie-consent": {
-      "version": "4.0.9",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-cookie-consent/-/vl-ui-cookie-consent-4.0.9.tgz",
-      "integrity": "sha1-eeFuTGXqW85sitPLe1PiUS5q48A=",
+      "version": "4.1.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-cookie-consent/-/vl-ui-cookie-consent-4.1.0.tgz",
+      "integrity": "sha1-Ml3b68vPtKUZOswG1Q0+ITWmc7o=",
       "requires": {
         "vl-ui-button": "5.0.6",
         "vl-ui-checkbox": "^3.2.0",
@@ -13285,16 +13572,18 @@
       }
     },
     "vl-ui-core": {
-      "version": "6.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-core/-/vl-ui-core-6.0.1.tgz",
-      "integrity": "sha1-xRsMjRZGIaycZG6K38sCjlataAI=",
+      "version": "6.1.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-core/-/vl-ui-core-6.1.0.tgz",
+      "integrity": "sha1-nsM/m+pphs3eB3C/UVp8TiSWPfM=",
       "requires": {
-        "document-register-element": "^1.14.5"
+        "@govflanders/vl-ui-core": "^4.0.5",
+        "@govflanders/vl-ui-util": "^3.11.5",
+        "@ungap/custom-elements": "^0.1.6"
       }
     },
     "vl-ui-data-table": {
       "version": "4.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-data-table/-/vl-ui-data-table-4.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-data-table/-/vl-ui-data-table-4.0.1.tgz",
       "integrity": "sha1-VinGfjRS/PLGC4Ks3WuH9WWmYgc=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13302,7 +13591,7 @@
     },
     "vl-ui-datepicker": {
       "version": "3.2.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-datepicker/-/vl-ui-datepicker-3.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-datepicker/-/vl-ui-datepicker-3.2.0.tgz",
       "integrity": "sha1-5LNW28jAHPo4RM6QDDR2Z7tN3rU=",
       "requires": {
         "vl-ui-core": "^6.0.0",
@@ -13314,7 +13603,7 @@
     },
     "vl-ui-demo": {
       "version": "1.2.3",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-demo/-/vl-ui-demo-1.2.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-demo/-/vl-ui-demo-1.2.3.tgz",
       "integrity": "sha1-Bnb+DheO1wgUp3WLfDeKDBL+240=",
       "requires": {
         "vl-ui-action-group": "^3.0.6",
@@ -13331,7 +13620,7 @@
     },
     "vl-ui-description-data": {
       "version": "3.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-description-data/-/vl-ui-description-data-3.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-description-data/-/vl-ui-description-data-3.0.5.tgz",
       "integrity": "sha1-CEUE8toIrt8EzT9dORMLCY961eg=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13339,7 +13628,7 @@
     },
     "vl-ui-document": {
       "version": "1.0.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-document/-/vl-ui-document-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-document/-/vl-ui-document-1.0.0.tgz",
       "integrity": "sha1-waZDCbmVcYGGviRIL5aFYY8xziU=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13347,7 +13636,7 @@
     },
     "vl-ui-doormat": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-doormat/-/vl-ui-doormat-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-doormat/-/vl-ui-doormat-1.0.0.tgz",
       "integrity": "sha1-lFbpKwrdO+Zf5UKtZt/agQZXEv8=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13355,7 +13644,7 @@
     },
     "vl-ui-footer": {
       "version": "3.2.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-footer/-/vl-ui-footer-3.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-footer/-/vl-ui-footer-3.2.1.tgz",
       "integrity": "sha1-kIk2D/DFxI81cXlEbSBuNaKtm7k=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13363,7 +13652,7 @@
     },
     "vl-ui-form": {
       "version": "1.0.2",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-form/-/vl-ui-form-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-form/-/vl-ui-form-1.0.2.tgz",
       "integrity": "sha1-Vmc732UCn0R4MyG043qtmtAtjjE=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13371,7 +13660,7 @@
     },
     "vl-ui-form-grid": {
       "version": "3.0.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-form-grid/-/vl-ui-form-grid-3.0.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-form-grid/-/vl-ui-form-grid-3.0.7.tgz",
       "integrity": "sha1-1046RPW7pRae5EMGRwrIJvn42hw=",
       "requires": {
         "vl-ui-core": "^6.0.0",
@@ -13380,7 +13669,7 @@
     },
     "vl-ui-form-message": {
       "version": "5.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-form-message/-/vl-ui-form-message-5.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-form-message/-/vl-ui-form-message-5.0.5.tgz",
       "integrity": "sha1-5EAwDhG7b8NkJ/3BAKkWEi8Q5vw=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13388,7 +13677,7 @@
     },
     "vl-ui-form-validation": {
       "version": "3.3.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-form-validation/-/vl-ui-form-validation-3.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-form-validation/-/vl-ui-form-validation-3.3.0.tgz",
       "integrity": "sha1-Yfj9/DWcJFiNEly4JhGhRG+Rq8g=",
       "requires": {
         "@govflanders/vl-ui-form-validation": "^4.0.6",
@@ -13397,7 +13686,7 @@
     },
     "vl-ui-functional-header": {
       "version": "1.2.7",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-functional-header/-/vl-ui-functional-header-1.2.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-functional-header/-/vl-ui-functional-header-1.2.7.tgz",
       "integrity": "sha1-cAHa6VMtEEoNNikc4kG3sGRYL44=",
       "requires": {
         "vl-ui-core": "^6.0.0",
@@ -13407,7 +13696,7 @@
     },
     "vl-ui-grid": {
       "version": "3.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-grid/-/vl-ui-grid-3.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-grid/-/vl-ui-grid-3.1.4.tgz",
       "integrity": "sha1-ycK1ChjV4f6jDVkQJNZ3nTJUOdI=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13415,7 +13704,7 @@
     },
     "vl-ui-header": {
       "version": "3.2.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-header/-/vl-ui-header-3.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-header/-/vl-ui-header-3.2.1.tgz",
       "integrity": "sha1-gnJ1/qzQlPLpEdk63WHfuMFvvx0=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13423,7 +13712,7 @@
     },
     "vl-ui-http-error-message": {
       "version": "3.2.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-http-error-message/-/vl-ui-http-error-message-3.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-http-error-message/-/vl-ui-http-error-message-3.2.1.tgz",
       "integrity": "sha1-rzjv93JUCEr6nwTE8jXcyQvFuy0=",
       "requires": {
         "vl-ui-button": "^5.0.6",
@@ -13435,7 +13724,7 @@
     },
     "vl-ui-icon": {
       "version": "5.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-icon/-/vl-ui-icon-5.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-icon/-/vl-ui-icon-5.2.0.tgz",
       "integrity": "sha1-pEScBCu72CYRNTHQ4cEsN+6MQH4=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13443,7 +13732,7 @@
     },
     "vl-ui-image": {
       "version": "3.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-image/-/vl-ui-image-3.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-image/-/vl-ui-image-3.0.5.tgz",
       "integrity": "sha1-yo/3tX0bN5XPzALi2t82S/l0EBE=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13451,7 +13740,7 @@
     },
     "vl-ui-info-tile": {
       "version": "1.0.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-info-tile/-/vl-ui-info-tile-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-info-tile/-/vl-ui-info-tile-1.0.0.tgz",
       "integrity": "sha1-juhu5PIO+w3pOyxNMflRkiv/gyQ=",
       "requires": {
         "vl-ui-accordion": "^3.0.9",
@@ -13460,7 +13749,7 @@
     },
     "vl-ui-infoblock": {
       "version": "3.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-infoblock/-/vl-ui-infoblock-3.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-infoblock/-/vl-ui-infoblock-3.0.6.tgz",
       "integrity": "sha1-VxAm1iiLwqY9YBIvPLFciB9nUKA=",
       "requires": {
         "vl-ui-core": "^6.0.0",
@@ -13469,7 +13758,7 @@
     },
     "vl-ui-infotext": {
       "version": "3.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-infotext/-/vl-ui-infotext-3.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-infotext/-/vl-ui-infotext-3.0.5.tgz",
       "integrity": "sha1-M0mViSvW2WYqIgzuYZ9nyr4Yex8=",
       "requires": {
         "@govflanders/vl-ui-infotext": "^3.11.5",
@@ -13478,7 +13767,7 @@
     },
     "vl-ui-input-addon": {
       "version": "3.1.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-input-addon/-/vl-ui-input-addon-3.1.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-input-addon/-/vl-ui-input-addon-3.1.5.tgz",
       "integrity": "sha1-g41SGmLI/yYoZq05W935l4komUc=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13486,7 +13775,7 @@
     },
     "vl-ui-input-field": {
       "version": "3.2.5",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-input-field/-/vl-ui-input-field-3.2.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-input-field/-/vl-ui-input-field-3.2.5.tgz",
       "integrity": "sha1-JpMTw2o4VaDohikG/n27Z5ERFLo=",
       "requires": {
         "vl-ui-core": "^6.0.1",
@@ -13496,7 +13785,7 @@
     },
     "vl-ui-input-group": {
       "version": "4.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-input-group/-/vl-ui-input-group-4.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-input-group/-/vl-ui-input-group-4.0.5.tgz",
       "integrity": "sha1-M6D/jsvrRmBtXnEPxaVnkMGoZA4=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13504,7 +13793,7 @@
     },
     "vl-ui-introduction": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-introduction/-/vl-ui-introduction-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-introduction/-/vl-ui-introduction-1.0.4.tgz",
       "integrity": "sha1-7QMjCETdpLtiltfgN9s25u5Oaoo=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13512,7 +13801,7 @@
     },
     "vl-ui-link": {
       "version": "4.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-link/-/vl-ui-link-4.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-link/-/vl-ui-link-4.0.5.tgz",
       "integrity": "sha1-IOMuy8ceKcmDg6HukWjnqXeQVEg=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13520,7 +13809,7 @@
     },
     "vl-ui-link-list": {
       "version": "3.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-link-list/-/vl-ui-link-list-3.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-link-list/-/vl-ui-link-list-3.0.6.tgz",
       "integrity": "sha1-nf2JQFujy/wAXWxR2hKY6MT4i6E=",
       "requires": {
         "vl-ui-core": "^6.0.0",
@@ -13529,7 +13818,7 @@
     },
     "vl-ui-loader": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-loader/-/vl-ui-loader-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-loader/-/vl-ui-loader-1.0.4.tgz",
       "integrity": "sha1-3gGiD/lJT4DDsXEcoPgqDn5K5Dw=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13547,7 +13836,7 @@
     },
     "vl-ui-modal": {
       "version": "4.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-modal/-/vl-ui-modal-4.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-modal/-/vl-ui-modal-4.0.1.tgz",
       "integrity": "sha1-KhIC8Ug/7F+YrC/pp81GZohyx1s=",
       "requires": {
         "@govflanders/vl-ui-core": "^4.0.5",
@@ -13560,7 +13849,7 @@
     },
     "vl-ui-multiselect": {
       "version": "4.0.8",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-multiselect/-/vl-ui-multiselect-4.0.8.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-multiselect/-/vl-ui-multiselect-4.0.8.tgz",
       "integrity": "sha1-yyEZUCV28n8GmrEr55xVfyqkyRQ=",
       "requires": {
         "@govflanders/vl-ui-core": "^4.0.5",
@@ -13572,7 +13861,7 @@
     },
     "vl-ui-pager": {
       "version": "3.0.9",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-pager/-/vl-ui-pager-3.0.9.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-pager/-/vl-ui-pager-3.0.9.tgz",
       "integrity": "sha1-X8ltDkrgXkxiHZT873OdjMwQBLc=",
       "requires": {
         "vl-ui-core": "^6.0.1"
@@ -13580,7 +13869,7 @@
     },
     "vl-ui-pattern": {
       "version": "1.0.5",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-pattern/-/vl-ui-pattern-1.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-pattern/-/vl-ui-pattern-1.0.5.tgz",
       "integrity": "sha1-B9Kj6Vv8v3d97Q+9wmqychAoArw=",
       "requires": {
         "@govflanders/vl-ui-pattern": "^3.11.5",
@@ -13589,7 +13878,7 @@
     },
     "vl-ui-pill": {
       "version": "4.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-pill/-/vl-ui-pill-4.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-pill/-/vl-ui-pill-4.0.5.tgz",
       "integrity": "sha1-RGffOy1m6la3CGEa/rffORFRbq0=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13597,7 +13886,7 @@
     },
     "vl-ui-progress-bar": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-progress-bar/-/vl-ui-progress-bar-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-progress-bar/-/vl-ui-progress-bar-1.1.2.tgz",
       "integrity": "sha1-CYjTV+5fLmIxDF3fA78ri4lvG64=",
       "requires": {
         "@govflanders/vl-ui-progress-bar": "^3.11.5",
@@ -13608,7 +13897,7 @@
     },
     "vl-ui-properties": {
       "version": "4.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-properties/-/vl-ui-properties-4.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-properties/-/vl-ui-properties-4.0.6.tgz",
       "integrity": "sha1-jgms27UXooPQDXA10dHA1bk8ma0=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13616,7 +13905,7 @@
     },
     "vl-ui-proza-message": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-proza-message/-/vl-ui-proza-message-1.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-proza-message/-/vl-ui-proza-message-1.1.3.tgz",
       "integrity": "sha1-Aupl0ZdeRxarbMubCjW3b7gT2uw=",
       "requires": {
         "tinymce": "^5.4.2",
@@ -13630,7 +13919,7 @@
     },
     "vl-ui-radio": {
       "version": "1.2.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-radio/-/vl-ui-radio-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-radio/-/vl-ui-radio-1.2.0.tgz",
       "integrity": "sha1-5RIknCidRArdQ3302mDBgZTlEKc=",
       "requires": {
         "vl-ui-core": "^6.0.1"
@@ -13638,7 +13927,7 @@
     },
     "vl-ui-rich-data": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-rich-data/-/vl-ui-rich-data-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-rich-data/-/vl-ui-rich-data-1.0.2.tgz",
       "integrity": "sha1-2FcrhEbMfXPGB/HqwDEbHSDskdo=",
       "requires": {
         "vl-ui-button": "^5.0.6",
@@ -13652,7 +13941,7 @@
     },
     "vl-ui-rich-data-table": {
       "version": "1.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-rich-data-table/-/vl-ui-rich-data-table-1.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-rich-data-table/-/vl-ui-rich-data-table-1.2.1.tgz",
       "integrity": "sha1-TbFq63ivtRXmW7AbdNmQEYv0OXs=",
       "requires": {
         "vl-ui-core": "^6.0.0",
@@ -13663,7 +13952,7 @@
     },
     "vl-ui-search": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-search/-/vl-ui-search-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-search/-/vl-ui-search-1.1.1.tgz",
       "integrity": "sha1-1Mz2VoULft4tCSaMPAmfiIJXImI=",
       "requires": {
         "vl-ui-button": "^5.0.6",
@@ -13675,7 +13964,7 @@
     },
     "vl-ui-search-filter": {
       "version": "3.1.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-search-filter/-/vl-ui-search-filter-3.1.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-search-filter/-/vl-ui-search-filter-3.1.5.tgz",
       "integrity": "sha1-Z7JwA0A/pNQOqJjufKkTP84/iQY=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13683,7 +13972,7 @@
     },
     "vl-ui-search-results": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-search-results/-/vl-ui-search-results-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-search-results/-/vl-ui-search-results-1.0.2.tgz",
       "integrity": "sha1-/I5L17btjP3dXtBoeo2nEvU8x1k=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13691,7 +13980,7 @@
     },
     "vl-ui-select": {
       "version": "4.1.5",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-select/-/vl-ui-select-4.1.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-select/-/vl-ui-select-4.1.5.tgz",
       "integrity": "sha1-jmyxZX8HOn3USZ8ck8IJQ4Rqnfw=",
       "requires": {
         "@govflanders/vl-ui-core": "^4.0.5",
@@ -13702,7 +13991,7 @@
     },
     "vl-ui-side-sheet": {
       "version": "3.0.7",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-side-sheet/-/vl-ui-side-sheet-3.0.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-side-sheet/-/vl-ui-side-sheet-3.0.7.tgz",
       "integrity": "sha1-9QOhGmqTOt5BSU16TeWHYq6juYg=",
       "requires": {
         "swipe-detect": "^1.0.1",
@@ -13712,7 +14001,7 @@
     },
     "vl-ui-steps": {
       "version": "1.1.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-steps/-/vl-ui-steps-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-steps/-/vl-ui-steps-1.1.0.tgz",
       "integrity": "sha1-o826wkTJ99pMVuLkQXvEPMguhoM=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13720,7 +14009,7 @@
     },
     "vl-ui-template": {
       "version": "3.1.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-template/-/vl-ui-template-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-template/-/vl-ui-template-3.1.0.tgz",
       "integrity": "sha1-ydbHfVNQSiuDOS0wZgQ3s2mr6HY=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13728,7 +14017,7 @@
     },
     "vl-ui-textarea": {
       "version": "3.2.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-textarea/-/vl-ui-textarea-3.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-textarea/-/vl-ui-textarea-3.2.0.tgz",
       "integrity": "sha1-sEjvD8xQicSGudWf++a4qeBj51Q=",
       "requires": {
         "tinymce": "^5.4.2",
@@ -13743,7 +14032,7 @@
     },
     "vl-ui-titles": {
       "version": "3.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-titles/-/vl-ui-titles-3.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-titles/-/vl-ui-titles-3.0.6.tgz",
       "integrity": "sha1-Cg1qn/OMz5nsRbcIllSBT1M5djM=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13751,7 +14040,7 @@
     },
     "vl-ui-toaster": {
       "version": "3.0.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-toaster/-/vl-ui-toaster-3.0.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-toaster/-/vl-ui-toaster-3.0.7.tgz",
       "integrity": "sha1-VmDWdxkxmeVdkMATrb07j0EGtII=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13767,16 +14056,16 @@
     },
     "vl-ui-typography": {
       "version": "3.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-typography/-/vl-ui-typography-3.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-typography/-/vl-ui-typography-3.1.2.tgz",
       "integrity": "sha1-o08hFNu13dJ+2kJXfx1y9B8dWos=",
       "requires": {
         "vl-ui-core": "^6.0.0"
       }
     },
     "vl-ui-upload": {
-      "version": "3.2.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-upload/-/vl-ui-upload-3.2.0.tgz",
-      "integrity": "sha1-DfYjB27CiyeNWC9RpuPJ+MiEtAM=",
+      "version": "3.3.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-upload/-/vl-ui-upload-3.3.1.tgz",
+      "integrity": "sha1-Sq7iFpmv8gRbrjzFYCsjS/48ZtA=",
       "requires": {
         "@govflanders/vl-ui-core": "^4.0.5",
         "@govflanders/vl-ui-util": "^3.11.5",
@@ -13785,42 +14074,45 @@
       }
     },
     "vl-ui-util": {
-      "version": "5.2.14",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-util/-/vl-ui-util-5.2.14.tgz",
-      "integrity": "sha1-UQpZUfYGnxflUegKUrEnLcLHJis=",
+      "version": "5.2.18",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-util/-/vl-ui-util-5.2.18.tgz",
+      "integrity": "sha1-AY9AqcMChQ7s+Ox/J4hUO7TOHcA=",
       "requires": {
+        "browserstack-local": "^1.4.8",
         "chai": "^4.2.0",
         "chai-as-promised": "^7.1.1",
-        "chromedriver": "^84.0.1",
-        "eslint": "^7.6.0",
+        "chromedriver": "^85.0.1",
+        "eslint": "^7.10.0",
         "eslint-config-google": "^0.14.0",
-        "eslint-plugin-html": "^6.0.3",
+        "eslint-plugin-html": "^6.1.0",
         "eslint-plugin-only-warn": "^1.0.2",
         "event-stream": "^4.0.1",
-        "fetch-mock": "^9.10.6",
+        "fetch-mock": "^9.10.7",
         "geckodriver": "^1.20.0",
         "http-server": "^0.12.3",
         "jsdom": "^16.4.0",
-        "luxon": "^1.24.1",
+        "luxon": "^1.25.0",
         "minify": "^5.1.1",
-        "mocha": "^8.1.1",
-        "np": "^6.4.0",
+        "mocha": "^8.1.3",
+        "mocha-multi-reporters": "^1.1.7",
+        "np": "^6.5.0",
         "replace": "^1.2.0",
-        "sass": "^1.26.10",
+        "sass": "^1.26.11",
         "selenium-webdriver": "^4.0.0-alpha.7",
-        "simple-git": "^2.17.0",
-        "sinon": "^9.0.3",
-        "terser": "^5.0.0",
-        "vl-ui-demo": "^1.2.2",
+        "simple-git": "^2.20.1",
+        "sinon": "^9.1.0",
+        "terser": "^5.3.4",
+        "vl-ui-demo": "^1.2.3",
         "wct-browser-legacy": "^1.0.2",
+        "wct-xunit-reporter": "^1.0.2",
         "web-component-tester": "^6.9.2",
         "yaml": "^1.10.0",
-        "yargs": "^15.4.1"
+        "yargs": "^16.0.3"
       }
     },
     "vl-ui-video-player": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-video-player/-/vl-ui-video-player-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-video-player/-/vl-ui-video-player-1.0.0.tgz",
       "integrity": "sha1-hEM2cAkM2ak02TSJ22V+Pm6L3EM=",
       "requires": {
         "vl-ui-core": "^6.0.0"
@@ -13828,7 +14120,7 @@
     },
     "vl-ui-wizard": {
       "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-wizard/-/vl-ui-wizard-1.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-wizard/-/vl-ui-wizard-1.3.0.tgz",
       "integrity": "sha1-jTDnFdwcLOa3bn7ct1mru+Sg+pQ=",
       "requires": {
         "vl-ui-action-group": "^3.0.6",
@@ -13839,27 +14131,27 @@
     },
     "vlq": {
       "version": "0.2.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vlq/-/vlq-0.2.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vlq/-/vlq-0.2.3.tgz",
       "integrity": "sha1-jz5DKM9jsVQMDWfhsneDhviXWyY="
     },
     "vscode-uri": {
       "version": "1.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vscode-uri/-/vscode-uri-1.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vscode-uri/-/vscode-uri-1.0.6.tgz",
       "integrity": "sha1-a48UGwu8RK17B+lPgvForHYIrU0="
     },
     "vue": {
       "version": "2.6.12",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vue/-/vue-2.6.12.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vue/-/vue-2.6.12.tgz",
       "integrity": "sha1-9evU+mvShpQD4pqJau1JBEVskSM="
     },
     "vue-multiselect": {
       "version": "2.1.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vue-multiselect/-/vue-multiselect-2.1.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vue-multiselect/-/vue-multiselect-2.1.6.tgz",
       "integrity": "sha1-W+XYEaIkgEoVxDpO27dIUCionH8="
     },
     "w3c-hr-time": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
       "integrity": "sha1-ConN9cwVgi35w2BUNnaWPgzDCM0=",
       "requires": {
         "browser-process-hrtime": "^1.0.0"
@@ -13867,7 +14159,7 @@
     },
     "w3c-xmlserializer": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
       "integrity": "sha1-PnEEoFt1FGzGD1ZDgLf2g6zxAgo=",
       "requires": {
         "xml-name-validator": "^3.0.0"
@@ -13875,7 +14167,7 @@
     },
     "wbuf": {
       "version": "1.7.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wbuf/-/wbuf-1.7.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wbuf/-/wbuf-1.7.3.tgz",
       "integrity": "sha1-wdjRSTFtPqhShIiVy2oL/oh7h98=",
       "requires": {
         "minimalistic-assert": "^1.0.0"
@@ -13883,7 +14175,7 @@
     },
     "wct-browser-legacy": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wct-browser-legacy/-/wct-browser-legacy-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wct-browser-legacy/-/wct-browser-legacy-1.0.2.tgz",
       "integrity": "sha1-a+ORdL034pAwKNPb0ikvnE7Fl2c=",
       "requires": {
         "@polymer/polymer": "^3.0.0",
@@ -13902,17 +14194,17 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-1.5.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "browser-stdout": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/browser-stdout/-/browser-stdout-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/browser-stdout/-/browser-stdout-1.3.0.tgz",
           "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
         },
         "chai": {
           "version": "3.5.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chai/-/chai-3.5.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chai/-/chai-3.5.0.tgz",
           "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
           "requires": {
             "assertion-error": "^1.0.1",
@@ -13922,7 +14214,7 @@
         },
         "commander": {
           "version": "2.9.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/commander/-/commander-2.9.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "requires": {
             "graceful-readlink": ">= 1.0.0"
@@ -13930,7 +14222,7 @@
         },
         "debug": {
           "version": "2.6.8",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.8.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.8.tgz",
           "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
           "requires": {
             "ms": "2.0.0"
@@ -13938,7 +14230,7 @@
         },
         "deep-eql": {
           "version": "0.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/deep-eql/-/deep-eql-0.1.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/deep-eql/-/deep-eql-0.1.3.tgz",
           "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
           "requires": {
             "type-detect": "0.1.1"
@@ -13946,19 +14238,19 @@
           "dependencies": {
             "type-detect": {
               "version": "0.1.1",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-detect/-/type-detect-0.1.1.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-detect/-/type-detect-0.1.1.tgz",
               "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
             }
           }
         },
         "diff": {
           "version": "3.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/diff/-/diff-3.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/diff/-/diff-3.2.0.tgz",
           "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
         },
         "glob": {
           "version": "7.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob/-/glob-7.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob/-/glob-7.1.1.tgz",
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -13971,32 +14263,32 @@
         },
         "growl": {
           "version": "1.9.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/growl/-/growl-1.9.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/growl/-/growl-1.9.2.tgz",
           "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
         },
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "he": {
           "version": "1.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/he/-/he-1.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/he/-/he-1.1.1.tgz",
           "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "requires": {
             "minimist": "0.0.8"
@@ -14004,7 +14296,7 @@
         },
         "mocha": {
           "version": "3.5.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mocha/-/mocha-3.5.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mocha/-/mocha-3.5.3.tgz",
           "integrity": "sha1-HgSA/jbS2lhY0etqzDhBiybqog0=",
           "requires": {
             "browser-stdout": "1.3.0",
@@ -14021,9 +14313,14 @@
             "supports-color": "3.1.2"
           }
         },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
         "sinon": {
           "version": "1.17.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sinon/-/sinon-1.17.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sinon/-/sinon-1.17.7.tgz",
           "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
           "requires": {
             "formatio": "1.1.1",
@@ -14034,7 +14331,7 @@
         },
         "supports-color": {
           "version": "3.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-3.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -14042,14 +14339,14 @@
         },
         "type-detect": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-detect/-/type-detect-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-detect/-/type-detect-1.0.0.tgz",
           "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
         }
       }
     },
     "wct-local": {
       "version": "2.1.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wct-local/-/wct-local-2.1.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wct-local/-/wct-local-2.1.5.tgz",
       "integrity": "sha1-95hnU+OtmjXTkXipmJNQUjVh//E=",
       "optional": true,
       "requires": {
@@ -14067,7 +14364,7 @@
       "dependencies": {
         "chalk": {
           "version": "2.4.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "optional": true,
           "requires": {
@@ -14080,7 +14377,7 @@
     },
     "wct-sauce": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wct-sauce/-/wct-sauce-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wct-sauce/-/wct-sauce-2.1.0.tgz",
       "integrity": "sha1-Z9C+NGqru8KDhOjRQ7jTynundMA=",
       "optional": true,
       "requires": {
@@ -14095,7 +14392,7 @@
       "dependencies": {
         "chalk": {
           "version": "2.4.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "optional": true,
           "requires": {
@@ -14106,9 +14403,17 @@
         }
       }
     },
+    "wct-xunit-reporter": {
+      "version": "1.0.2",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wct-xunit-reporter/-/wct-xunit-reporter-1.0.2.tgz",
+      "integrity": "sha1-x+p9sxw+vzysXcfN13aNSPOXHjg=",
+      "requires": {
+        "xmlbuilder": "^15.1.1"
+      }
+    },
     "wd": {
       "version": "1.13.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wd/-/wd-1.13.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wd/-/wd-1.13.0.tgz",
       "integrity": "sha1-edgsV+C7f8yi8pHth/Uc9rdwH/A=",
       "requires": {
         "archiver": "^3.0.0",
@@ -14122,12 +14427,12 @@
       "dependencies": {
         "punycode": {
           "version": "1.4.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/punycode/-/punycode-1.4.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         },
         "request": {
           "version": "2.88.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/request/-/request-2.88.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/request/-/request-2.88.0.tgz",
           "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
           "requires": {
             "aws-sign2": "~0.7.0",
@@ -14154,7 +14459,7 @@
         },
         "tough-cookie": {
           "version": "2.4.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tough-cookie/-/tough-cookie-2.4.3.tgz",
           "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
           "requires": {
             "psl": "^1.1.24",
@@ -14165,7 +14470,7 @@
     },
     "web-component-tester": {
       "version": "6.9.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/web-component-tester/-/web-component-tester-6.9.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/web-component-tester/-/web-component-tester-6.9.2.tgz",
       "integrity": "sha1-QKe4JPLPPLxDBVUr38M1eXfe1Io=",
       "requires": {
         "@polymer/sinonjs": "^1.14.1",
@@ -14200,17 +14505,17 @@
       "dependencies": {
         "@polymer/test-fixture": {
           "version": "0.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@polymer/test-fixture/-/test-fixture-0.0.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@polymer/test-fixture/-/test-fixture-0.0.3.tgz",
           "integrity": "sha1-REN1JpfU2Sk7vEEuoLXk00HxSdk="
         },
         "@webcomponents/webcomponentsjs": {
           "version": "1.3.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.3.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.3.3.tgz",
           "integrity": "sha1-W7gqDTIQyDa9RiPhOkqTFFy53Cc="
         },
         "ansi-align": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-align/-/ansi-align-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-align/-/ansi-align-2.0.0.tgz",
           "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
           "optional": true,
           "requires": {
@@ -14219,18 +14524,18 @@
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "optional": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "boxen": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/boxen/-/boxen-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/boxen/-/boxen-1.3.0.tgz",
           "integrity": "sha1-VcbDmouljZxhrSLNh3Uy3rZlogs=",
           "optional": true,
           "requires": {
@@ -14245,7 +14550,7 @@
           "dependencies": {
             "ansi-styles": {
               "version": "3.2.1",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
               "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
               "optional": true,
               "requires": {
@@ -14254,7 +14559,7 @@
             },
             "chalk": {
               "version": "2.4.2",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
               "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
               "optional": true,
               "requires": {
@@ -14265,7 +14570,7 @@
             },
             "supports-color": {
               "version": "5.5.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-5.5.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
               "optional": true,
               "requires": {
@@ -14276,13 +14581,13 @@
         },
         "camelcase": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase/-/camelcase-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "optional": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -14294,19 +14599,19 @@
         },
         "ci-info": {
           "version": "1.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ci-info/-/ci-info-1.6.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ci-info/-/ci-info-1.6.0.tgz",
           "integrity": "sha1-LKINu5zrMtRSSmgzAzE/AwSx5Jc=",
           "optional": true
         },
         "cli-boxes": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-boxes/-/cli-boxes-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cli-boxes/-/cli-boxes-1.0.0.tgz",
           "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
           "optional": true
         },
         "configstore": {
           "version": "3.1.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/configstore/-/configstore-3.1.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/configstore/-/configstore-3.1.5.tgz",
           "integrity": "sha1-6a8zH63BTavVRNPn523ERqCaUw8=",
           "optional": true,
           "requires": {
@@ -14320,7 +14625,7 @@
         },
         "cross-spawn": {
           "version": "5.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "optional": true,
           "requires": {
@@ -14331,18 +14636,18 @@
         },
         "crypto-random-string": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
           "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
           "optional": true
         },
         "diff": {
           "version": "3.5.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/diff/-/diff-3.5.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/diff/-/diff-3.5.0.tgz",
           "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI="
         },
         "dot-prop": {
           "version": "4.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dot-prop/-/dot-prop-4.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/dot-prop/-/dot-prop-4.2.1.tgz",
           "integrity": "sha1-RYhBlKcfws2nHLtLzrOk3S9DO6Q=",
           "optional": true,
           "requires": {
@@ -14351,7 +14656,7 @@
         },
         "execa": {
           "version": "0.7.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/execa/-/execa-0.7.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "optional": true,
           "requires": {
@@ -14366,7 +14671,7 @@
         },
         "formatio": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/formatio/-/formatio-1.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/formatio/-/formatio-1.2.0.tgz",
           "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
           "requires": {
             "samsam": "1.x"
@@ -14374,13 +14679,13 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "optional": true
         },
         "global-dirs": {
           "version": "0.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/global-dirs/-/global-dirs-0.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/global-dirs/-/global-dirs-0.1.1.tgz",
           "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
           "optional": true,
           "requires": {
@@ -14389,7 +14694,7 @@
         },
         "got": {
           "version": "6.7.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/got/-/got-6.7.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/got/-/got-6.7.1.tgz",
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "optional": true,
           "requires": {
@@ -14408,7 +14713,7 @@
         },
         "is-ci": {
           "version": "1.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-ci/-/is-ci-1.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-ci/-/is-ci-1.2.1.tgz",
           "integrity": "sha1-43ecjuF/zPQoSI9uKBGH8uYyhBw=",
           "optional": true,
           "requires": {
@@ -14417,13 +14722,13 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "optional": true
         },
         "is-installed-globally": {
           "version": "0.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
           "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
           "optional": true,
           "requires": {
@@ -14433,19 +14738,19 @@
         },
         "is-npm": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-npm/-/is-npm-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-npm/-/is-npm-1.0.0.tgz",
           "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
           "optional": true
         },
         "is-obj": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-obj/-/is-obj-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-obj/-/is-obj-1.0.1.tgz",
           "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
           "optional": true
         },
         "is-path-inside": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-path-inside/-/is-path-inside-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-path-inside/-/is-path-inside-1.0.1.tgz",
           "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
           "optional": true,
           "requires": {
@@ -14454,7 +14759,7 @@
         },
         "latest-version": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/latest-version/-/latest-version-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/latest-version/-/latest-version-3.1.0.tgz",
           "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
           "optional": true,
           "requires": {
@@ -14463,17 +14768,17 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         },
         "lolex": {
           "version": "1.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lolex/-/lolex-1.6.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lolex/-/lolex-1.6.0.tgz",
           "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY="
         },
         "lru-cache": {
           "version": "4.1.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lru-cache/-/lru-cache-4.1.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lru-cache/-/lru-cache-4.1.5.tgz",
           "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
           "optional": true,
           "requires": {
@@ -14483,7 +14788,7 @@
         },
         "make-dir": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/make-dir/-/make-dir-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/make-dir/-/make-dir-1.3.0.tgz",
           "integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
           "optional": true,
           "requires": {
@@ -14492,7 +14797,7 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
           "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "optional": true,
           "requires": {
@@ -14501,7 +14806,7 @@
         },
         "package-json": {
           "version": "4.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/package-json/-/package-json-4.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/package-json/-/package-json-4.0.1.tgz",
           "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
           "optional": true,
           "requires": {
@@ -14513,13 +14818,13 @@
         },
         "path-key": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-key/-/path-key-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-key/-/path-key-2.0.1.tgz",
           "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "optional": true
         },
         "path-to-regexp": {
           "version": "1.8.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
           "integrity": "sha1-iHs7qdhDk+h6CgufTLdWGYtTVIo=",
           "requires": {
             "isarray": "0.0.1"
@@ -14527,13 +14832,13 @@
         },
         "pify": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "optional": true
         },
         "registry-auth-token": {
           "version": "3.4.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
           "integrity": "sha1-10RoFUM/XV7WQxzV3KIQSPZrOX4=",
           "optional": true,
           "requires": {
@@ -14543,7 +14848,7 @@
         },
         "registry-url": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/registry-url/-/registry-url-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/registry-url/-/registry-url-3.1.0.tgz",
           "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
           "optional": true,
           "requires": {
@@ -14552,12 +14857,12 @@
         },
         "samsam": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/samsam/-/samsam-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/samsam/-/samsam-1.3.0.tgz",
           "integrity": "sha1-jR2TUOJWItow3j5EumkrUiGrfFA="
         },
         "semver-diff": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver-diff/-/semver-diff-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/semver-diff/-/semver-diff-2.1.0.tgz",
           "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
           "optional": true,
           "requires": {
@@ -14566,7 +14871,7 @@
         },
         "shebang-command": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shebang-command/-/shebang-command-1.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/shebang-command/-/shebang-command-1.2.0.tgz",
           "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "optional": true,
           "requires": {
@@ -14575,13 +14880,13 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
           "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "optional": true
         },
         "sinon": {
           "version": "2.4.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sinon/-/sinon-2.4.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sinon/-/sinon-2.4.1.tgz",
           "integrity": "sha1-Ah/WS1TLd9nS+w1Dze3652KcOjY=",
           "requires": {
             "diff": "^3.1.0",
@@ -14596,7 +14901,7 @@
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "optional": true,
           "requires": {
@@ -14606,7 +14911,7 @@
           "dependencies": {
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "optional": true,
               "requires": {
@@ -14617,12 +14922,12 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         },
         "term-size": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/term-size/-/term-size-1.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/term-size/-/term-size-1.2.0.tgz",
           "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
           "optional": true,
           "requires": {
@@ -14631,13 +14936,13 @@
         },
         "timed-out": {
           "version": "4.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/timed-out/-/timed-out-4.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/timed-out/-/timed-out-4.0.1.tgz",
           "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
           "optional": true
         },
         "unique-string": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unique-string/-/unique-string-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unique-string/-/unique-string-1.0.0.tgz",
           "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
           "optional": true,
           "requires": {
@@ -14646,13 +14951,13 @@
         },
         "unzip-response": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unzip-response/-/unzip-response-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unzip-response/-/unzip-response-2.0.1.tgz",
           "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
           "optional": true
         },
         "update-notifier": {
           "version": "2.5.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/update-notifier/-/update-notifier-2.5.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/update-notifier/-/update-notifier-2.5.0.tgz",
           "integrity": "sha1-0HRFk+E/Fh5AassdlAi3LK0Ir/Y=",
           "optional": true,
           "requires": {
@@ -14670,7 +14975,7 @@
           "dependencies": {
             "ansi-styles": {
               "version": "3.2.1",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
               "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
               "optional": true,
               "requires": {
@@ -14679,7 +14984,7 @@
             },
             "chalk": {
               "version": "2.4.2",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
               "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
               "optional": true,
               "requires": {
@@ -14690,7 +14995,7 @@
             },
             "supports-color": {
               "version": "5.5.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-5.5.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
               "optional": true,
               "requires": {
@@ -14701,7 +15006,7 @@
         },
         "widest-line": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/widest-line/-/widest-line-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/widest-line/-/widest-line-2.0.1.tgz",
           "integrity": "sha1-dDh2RzDsfvQ4HOTfgvuYpTFCo/w=",
           "optional": true,
           "requires": {
@@ -14710,7 +15015,7 @@
         },
         "write-file-atomic": {
           "version": "2.4.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
           "integrity": "sha1-H9Lprh3z51uNjDZ0Q8aS1MqB9IE=",
           "optional": true,
           "requires": {
@@ -14721,13 +15026,13 @@
         },
         "xdg-basedir": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
           "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
           "optional": true
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yallist/-/yallist-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "optional": true
         }
@@ -14735,7 +15040,7 @@
     },
     "webfonts-generator": {
       "version": "0.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/webfonts-generator/-/webfonts-generator-0.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/webfonts-generator/-/webfonts-generator-0.4.0.tgz",
       "integrity": "sha1-X4n8gccWDm4Mu8m3OH5CpYUf2kY=",
       "requires": {
         "handlebars": "^4.0.5",
@@ -14752,12 +15057,12 @@
     },
     "webidl-conversions": {
       "version": "4.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha1-qFWYCx8LazWbodXZ+zmulB+qY60="
     },
     "whatwg-encoding": {
       "version": "1.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
       "integrity": "sha1-WrrPd3wyFmpR0IXWtPPn0nET3bA=",
       "requires": {
         "iconv-lite": "0.4.24"
@@ -14765,12 +15070,12 @@
     },
     "whatwg-mimetype": {
       "version": "2.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
       "integrity": "sha1-PUseAxLSB5h5+Cav8Y2+7KWWD78="
     },
     "whatwg-url": {
       "version": "6.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/whatwg-url/-/whatwg-url-6.5.0.tgz",
       "integrity": "sha1-8t8Cv/F2/WUHDfdK1cy7WhmZZag=",
       "requires": {
         "lodash.sortby": "^4.7.0",
@@ -14780,7 +15085,7 @@
     },
     "which": {
       "version": "1.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/which/-/which-1.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/which/-/which-1.3.1.tgz",
       "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
       "requires": {
         "isexe": "^2.0.0"
@@ -14788,12 +15093,12 @@
     },
     "which-module": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/which-module/-/which-module-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "which-typed-array": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/which-typed-array/-/which-typed-array-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/which-typed-array/-/which-typed-array-1.1.2.tgz",
       "integrity": "sha1-5fmOVr2pPj2sGWsB1HwRVmecALI=",
       "requires": {
         "available-typed-arrays": "^1.0.2",
@@ -14806,7 +15111,7 @@
     },
     "wide-align": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wide-align/-/wide-align-1.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
       "requires": {
         "string-width": "^1.0.2 || 2"
@@ -14814,7 +15119,7 @@
     },
     "widest-line": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/widest-line/-/widest-line-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/widest-line/-/widest-line-3.1.0.tgz",
       "integrity": "sha1-gpIzO79my0X/DeFgOxNreuFJbso=",
       "requires": {
         "string-width": "^4.0.0"
@@ -14822,22 +15127,22 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U="
         },
         "emoji-regex": {
           "version": "8.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
           "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc="
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0="
         },
         "string-width": {
           "version": "4.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
           "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -14847,7 +15152,7 @@
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
           "requires": {
             "ansi-regex": "^5.0.0"
@@ -14857,7 +15162,7 @@
     },
     "winston": {
       "version": "3.3.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/winston/-/winston-3.3.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/winston/-/winston-3.3.3.tgz",
       "integrity": "sha1-rmFyBCyvspeGr6PQnI/4M6t8kXA=",
       "requires": {
         "@dabh/diagnostics": "^2.0.2",
@@ -14873,22 +15178,22 @@
       "dependencies": {
         "async": {
           "version": "3.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-3.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/async/-/async-3.2.0.tgz",
           "integrity": "sha1-s6JoXF67ZB094C0WEALGD8n4VyA="
         },
         "fecha": {
           "version": "4.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fecha/-/fecha-4.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fecha/-/fecha-4.2.0.tgz",
           "integrity": "sha1-P/tjlUU+Pz7/+FBATwpZtnR/X0E="
         },
         "is-stream": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-stream/-/is-stream-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-stream/-/is-stream-2.0.0.tgz",
           "integrity": "sha1-venDJoDW+uBBKdasnZIc54FfeOM="
         },
         "logform": {
           "version": "2.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/logform/-/logform-2.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/logform/-/logform-2.2.0.tgz",
           "integrity": "sha1-QPA20ZFh/Ha2irUP3H/klVREkvI=",
           "requires": {
             "colors": "^1.2.1",
@@ -14898,14 +15203,9 @@
             "triple-beam": "^1.3.0"
           }
         },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
-        },
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.6.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
           "requires": {
             "inherits": "^2.0.3",
@@ -14915,12 +15215,12 @@
         },
         "safe-buffer": {
           "version": "5.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY="
         },
         "string_decoder": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.3.0.tgz",
           "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
           "requires": {
             "safe-buffer": "~5.2.0"
@@ -14930,7 +15230,7 @@
     },
     "winston-transport": {
       "version": "4.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/winston-transport/-/winston-transport-4.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/winston-transport/-/winston-transport-4.4.0.tgz",
       "integrity": "sha1-F69RjappDVsuzMqnrPeyDKeSXlk=",
       "requires": {
         "readable-stream": "^2.3.7",
@@ -14939,17 +15239,17 @@
     },
     "word-wrap": {
       "version": "1.2.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/word-wrap/-/word-wrap-1.2.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha1-YQY29rH3A4kb00dxzLF/uTtHB5w="
     },
     "wordwrap": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wordwrap/-/wordwrap-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
     },
     "wordwrapjs": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
       "integrity": "sha1-yUw3KJTK3G/rGma/9k4dmvksXR4=",
       "requires": {
         "reduce-flatten": "^1.0.1",
@@ -14958,19 +15258,19 @@
       "dependencies": {
         "typical": {
           "version": "2.6.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typical/-/typical-2.6.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/typical/-/typical-2.6.1.tgz",
           "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
         }
       }
     },
     "workerpool": {
-      "version": "6.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/workerpool/-/workerpool-6.0.0.tgz",
-      "integrity": "sha1-harWf6GiyO+ThqG0NTmQD2HQPVg="
+      "version": "6.0.2",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/workerpool/-/workerpool-6.0.2.tgz",
+      "integrity": "sha1-4kG0PY0DPxvrUseFEGlFYDnR1Dg="
     },
     "wrap-ansi": {
       "version": "5.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
       "requires": {
         "ansi-styles": "^3.2.0",
@@ -14980,17 +15280,17 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "requires": {
             "emoji-regex": "^7.0.1",
@@ -15000,7 +15300,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -15010,12 +15310,12 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/write/-/write-1.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/write/-/write-1.0.3.tgz",
       "integrity": "sha1-CADhRSO5I6OH5BUSPIZWFqrg9cM=",
       "requires": {
         "mkdirp": "^0.5.1"
@@ -15023,7 +15323,7 @@
     },
     "write-file-atomic": {
       "version": "3.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
       "integrity": "sha1-Vr1cWlxwSBzRnFcb05q5ZaXeVug=",
       "requires": {
         "imurmurhash": "^0.1.4",
@@ -15034,105 +15334,105 @@
     },
     "ws": {
       "version": "7.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ws/-/ws-7.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ws/-/ws-7.3.1.tgz",
       "integrity": "sha1-0FR79n985PEqct/jEmLGjX3FUcg="
     },
     "xdg-basedir": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
       "integrity": "sha1-S8jZmEQDaWIl74OhVzy7y0552xM="
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha1-auc+Bt5NjG5H+fsYH3jWSK1FfGo="
     },
     "xmlbuilder": {
-      "version": "8.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
-      "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
-      "optional": true
+      "version": "15.1.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha1-nc3OSe6mbY0QtCyulKecPI0MLsU="
     },
     "xmlchars": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xmlchars/-/xmlchars-2.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha1-Bg/hvLf5x2/ioX24apvDq4lCEMs="
     },
     "xmldom": {
       "version": "0.1.31",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xmldom/-/xmldom-0.1.31.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xmldom/-/xmldom-0.1.31.tgz",
       "integrity": "sha1-t2yaG9nwqXN+WnLcNyMc84N14v8="
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
       "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
     },
     "xtend": {
       "version": "4.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xtend/-/xtend-4.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q="
     },
     "y18n": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/y18n/-/y18n-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms="
     },
     "yallist": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yallist/-/yallist-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI="
     },
     "yaml": {
       "version": "1.10.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yaml/-/yaml-1.10.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yaml/-/yaml-1.10.0.tgz",
       "integrity": "sha1-O1k63ZRIdgd9TWg/7gEIG9n/8x4="
     },
     "yargs": {
-      "version": "15.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha1-DYehbeAa7p2L7Cv7909nhRcw9Pg=",
+      "version": "16.1.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs/-/yargs-16.1.0.tgz",
+      "integrity": "sha1-/DM/5HkWYOrOWolLOdQvhRzUjyo=",
       "requires": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
         "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
+        "y18n": "^5.0.2",
+        "yargs-parser": "^20.2.2"
       },
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U="
         },
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha1-kK51xCTQCNJiTFvynq0xd+v881k=",
+          "version": "4.3.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
         "cliui": {
-          "version": "6.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cliui/-/cliui-6.0.0.tgz",
-          "integrity": "sha1-UR1wLAxOQcoVbX0OlgIfI+EyJbE=",
+          "version": "7.0.3",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cliui/-/cliui-7.0.3.tgz",
+          "integrity": "sha1-7xgPJsjZv/OSfuUkKL/sIJBCeYE=",
           "requires": {
             "string-width": "^4.2.0",
             "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^6.2.0"
+            "wrap-ansi": "^7.0.0"
           }
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "requires": {
             "color-name": "~1.1.4"
@@ -15140,55 +15440,22 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
         },
         "emoji-regex": {
           "version": "8.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
           "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc="
-        },
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0="
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
         },
         "string-width": {
           "version": "4.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
           "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -15198,36 +15465,37 @@
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
           "requires": {
             "ansi-regex": "^5.0.0"
           }
         },
         "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha1-6Tk7oHEC5skaOyIUePAlfNKFblM=",
+          "version": "7.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
           "requires": {
             "ansi-styles": "^4.0.0",
             "string-width": "^4.1.0",
             "strip-ansi": "^6.0.0"
           }
         },
+        "y18n": {
+          "version": "5.0.4",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/y18n/-/y18n-5.0.4.tgz",
+          "integrity": "sha1-CrLbid1Yc7XsRoLY5wPoMzc+qJc="
+        },
         "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha1-vmjEl1xrKr9GkjawyHA2L6sJp7A=",
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
+          "version": "20.2.3",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-20.2.3.tgz",
+          "integrity": "sha1-kkGbqGe4WMhorPi66b90rw3QziY="
         }
       }
     },
     "yargs-parser": {
       "version": "13.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-13.1.2.tgz",
       "integrity": "sha1-Ew8JcC667vJlDVTObj5XBvek+zg=",
       "requires": {
         "camelcase": "^5.0.0",
@@ -15235,115 +15503,36 @@
       }
     },
     "yargs-unparser": {
-      "version": "1.6.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs-unparser/-/yargs-unparser-1.6.1.tgz",
-      "integrity": "sha1-vUsO4FtMlNBYkpwyywnj/OcdPF8=",
+      "version": "2.0.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha1-8TH5ImkRrl2a04xDL+gJNmwjJes=",
       "requires": {
-        "camelcase": "^5.3.1",
-        "decamelize": "^1.2.0",
-        "flat": "^4.1.0",
-        "is-plain-obj": "^1.1.0",
-        "yargs": "^14.2.3"
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
+        "camelcase": {
+          "version": "6.1.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/camelcase/-/camelcase-6.1.0.tgz",
+          "integrity": "sha1-J9wXYXNyX7Ct+KSLZH9NeHGUTXg="
         },
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
+        "decamelize": {
+          "version": "4.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/decamelize/-/decamelize-4.0.0.tgz",
+          "integrity": "sha1-qkcte/Zg6xXzSU79UxyrfypwmDc="
         },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
-        "yargs": {
-          "version": "14.2.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs/-/yargs-14.2.3.tgz",
-          "integrity": "sha1-Ghw+3O0a+yov6jNgS8bR2NaIpBQ=",
-          "requires": {
-            "cliui": "^5.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^15.0.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "15.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-15.0.1.tgz",
-          "integrity": "sha1-VHhq9AuCDcsvuAJbEbTWWddjI7M=",
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
+        "is-plain-obj": {
+          "version": "2.1.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha1-ReQuN/zPH0Dajl927iFRWEDAkoc="
         }
       }
     },
     "yauzl": {
       "version": "2.10.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yauzl/-/yauzl-2.10.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "requires": {
         "buffer-crc32": "~0.2.3",
@@ -15352,12 +15541,12 @@
     },
     "yeast": {
       "version": "0.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yeast/-/yeast-0.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
     },
     "zip-stream": {
       "version": "2.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/zip-stream/-/zip-stream-2.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/zip-stream/-/zip-stream-2.1.3.tgz",
       "integrity": "sha1-JsxL25NkGoWQ3QcRLh93rxdYhls=",
       "requires": {
         "archiver-utils": "^2.1.0",
@@ -15367,7 +15556,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.6.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
           "requires": {
             "inherits": "^2.0.3",
@@ -15377,12 +15566,12 @@
         },
         "safe-buffer": {
           "version": "5.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY="
         },
         "string_decoder": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.3.0.tgz",
           "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
           "requires": {
             "safe-buffer": "~5.2.0"

--- a/package.json
+++ b/package.json
@@ -100,6 +100,8 @@
     "vl-ui-wizard": "^1.2.3"
   },
   "devDependencies": {
-    "copyfiles": "2.4.0"
+    "copyfiles": "2.4.0",
+    "mocha-junit-reporter": "^2.0.0",
+    "mocha-multi-reporters": "^1.1.7"
   }
 }

--- a/reporter-config.json
+++ b/reporter-config.json
@@ -1,0 +1,6 @@
+{
+    "reporterEnabled": "spec,mocha-junit-reporter",
+    "mochaJunitReporterReporterOptions": {
+        "mochaFile": "./test/test-results.xml"
+    }
+}


### PR DESCRIPTION
Gebruik maken van de mocha-multi-reporters zodat zowel spec als junit als reporter kan gebruikt worden.
Op deze manier worden de testresultaten naar stdout geprint alsook naar junit XML-formaat zodat Bamboo deze kan uitlezen.﻿
